### PR TITLE
Suse support for PHP Agent and Server Monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This cookbook recommends on the following cookbooks:
 * Fedora
 * Scientific
 * Amazon
+* Suse
 * Windows
 * SmartOS
 
@@ -107,6 +108,8 @@ Attributes
 * `node['newrelic']['startup_mode']` - The newrelic-daemon startup mode ("agent"/"external"), defaults to "agent"
 * `node['newrelic']['web_server']['service_name']` - The web server service name, defaults to "apache2"
 * `node['newrelic']['php_recipe']` - The php recipe to include for the php agent, defaults to "php::default"
+* `node['newrelic']['php_tar_version']` - the version number of the PHP agent to install from tar.gz
+* `node['newrelic']['php_tar_baseurl']` - base URL to download the tar.gz version (defaults to "https://download.newrelic.com/php_agent/release/newrelic-php5")
 
 ## python-agent.rb:
 * `node['newrelic']['python_version']` - Defaults to "latest". Version numbers can be found at http://download.newrelic.com/python_agent/release/
@@ -121,6 +124,8 @@ Attributes
 * `node['newrelic']['service_name']` - The New Relic server monitoring service name, defaults to "newrelic-sysmond"
 * `node['newrelic']['config_path']` - The New Relic server monitoring config path, defaults to "/etc/newrelic"
 * `node['newrelic']['config_file_group']` - The New Relic server monitoring config file group, defaults to "newrelic"
+* `node['newrelic']['sysmond_tar_version']` - the version number of the tar.gz Server Monitor package
+* `node['newrelic']['sysmond_tar_baseurl']` - base URL to download the tar.gz version (defaults to "https://download.newrelic.com/server_monitor/release/newrelic-sysmond")
 
 ## java-agent.rb:
 * `node['newrelic']['https_download']` - The url to download the jar vor the NewRelic java agent

--- a/attributes/php-agent.rb
+++ b/attributes/php-agent.rb
@@ -8,3 +8,8 @@
 default['newrelic']['startup_mode'] = "agent"
 default['newrelic']['web_server']['service_name'] = "apache2"
 default['newrelic']['php_recipe'] = "php::default"
+
+# targz install  method
+default['newrelic']['php_tar_version'] = "4.3.5.33"
+# full url exemple https://download.newrelic.com/php_agent/release/newrelic-php5-4.3.5.33-linux.tar.gz
+default['newrelic']['php_tar_baseurl'] = "https://download.newrelic.com/php_agent/release/newrelic-php5"

--- a/attributes/server-monitor.rb
+++ b/attributes/server-monitor.rb
@@ -8,3 +8,7 @@
 default['newrelic']['service_name'] = "newrelic-sysmond"
 default['newrelic']['config_path'] = "/etc/newrelic"
 default['newrelic']['config_file_group'] = "newrelic"
+
+# targz install  method
+default['newrelic']['sysmond_tar_version'] = "1.3.1.437"
+default['newrelic']['sysmond_tar_baseurl'] = "https://download.newrelic.com/server_monitor/release/newrelic-sysmond"

--- a/recipes/server-monitor.rb
+++ b/recipes/server-monitor.rb
@@ -6,39 +6,110 @@
 #
 
 case node['platform']
-    when "debian", "ubuntu", "redhat", "centos", "fedora", "scientific", "amazon", "smartos"
-        package node['newrelic']['service_name'] do
-            action :install
-        end
+when "debian", "ubuntu", "redhat", "centos", "fedora", "scientific", "amazon", "smartos", "suse"
 
-        #configure your New Relic license key
-        template "#{node['newrelic']['config_path']}/nrsysmond.cfg" do
-            source "nrsysmond.cfg.erb"
-            owner "root"
-            group node['newrelic']['config_file_group']
-            mode "640"
-            variables(
-                :license => node['newrelic']['server_monitoring']['license'],
-                :logfile => node['newrelic']['server_monitoring']['logfile'],
-                :loglevel => node['newrelic']['server_monitoring']['loglevel'],
-                :proxy => node['newrelic']['server_monitoring']['proxy'],
-                :ssl => node['newrelic']['server_monitoring']['ssl'],
-                :ssl_ca_path => node['newrelic']['server_monitoring']['ssl_ca_path'],
-                :ssl_ca_bundle => node['newrelic']['server_monitoring']['ssl_ca_bundle'],
-                :pidfile => node['newrelic']['server_monitoring']['pidfile'],
-                :collector_host => node['newrelic']['server_monitoring']['collector_host'],
-                :timeout => node['newrelic']['server_monitoring']['timeout']
-            )
-            notifies :restart, "service[#{node['newrelic']['service_name']}]"
-        end
+  case node['platform']
+  when "suse"
+    # should work with bsd, osx, solaris and all
+    # sorry, long and ugly. We apre probably repeating what is normally done by the package manager...
 
-        service node['newrelic']['service_name'] do
-            supports :status => true, :start => true, :stop => true, :restart => true
-            action [:enable, :start] #starts the service if it's not running and enables it to start at system boot time
-        end
-    when "windows"
+    group "newrelic" do
+      action :create
+    end
+
+    tarname = 'newrelic-sysmond.tar.gz'
+    sysmond_tar = "#{Chef::Config[:file_cache_path]}/#{tarname}"
+    untardir = "#{Chef::Config[:file_cache_path]}/newrelic-sysmond-latest"
+
+    tarurl = [node['newrelic']['sysmond_tar_baseurl'], node['newrelic']['sysmond_tar_version'], "linux.tar.gz"].join '-'
+    pkgname = tarurl.split('/')[-1].gsub /.tar.gz/, ''
+
+    remote_file sysmond_tar do
+      source tarurl
+      owner "root"
+      group "root"
+      mode 0644
+      notifies :run, "execute[newrelic-cleanup-sysmond]", :immediately
+      notifies :run, "execute[newrelic-untar-sysmond]", :immediately
+      action :create_if_missing
+    end
+
+    directory untardir do
+      mode 0755
+      action :create
+    end
+
+    execute "newrelic-cleanup-sysmond" do
+      command "rm -rf #{untardir}"
+      action :nothing
+      notifies :create, "directory[#{untardir}]", :immediately
+    end
+
+    execute "newrelic-untar-sysmond" do
+      command "tar xfz #{sysmond_tar} -C #{untardir}"
+      notifies :run, "execute[newrelic-install-sysmond]", :immediately
+    end
+
+    directory "/etc/newrelic" do
+      action :create
+    end
+
+    # This stinks: we make sure not to reload on every run, but we may ends up
+    # not being able to overwrite (Text file busy error) our file if it indeed changes.
+    # Would need a big pile of stop-if-this-or-that resource... dammit
+    log("cp #{untardir}/*/daemon/nrsysmond.#{ node['kernel']['machine'] == "x86_64" ? "x64" : "x86" } /usr/local/sbin/nrsysmond ; cp #{untardir}/*/scripts/nrsysmond-config /usr/local/sbin") { level :warn}
+    execute "newrelic-install-sysmond" do
+      not_if "diff -q #{untardir}/*/daemon/nrsysmond.#{ node['kernel']['machine'] == "x86_64" ? "x64" : "x86" } /usr/local/sbin/nrsysmond "
+      # we use * so that we don't have to know the exact name of the tarball content
+      command "cp #{untardir}/*/daemon/nrsysmond.#{ node['kernel']['machine'] == "x86_64" ? "x64" : "x86" } /usr/local/sbin/nrsysmond "
+    end
+
+    # Use template name per-platform discovery to set correctly your platform
+    template "/etc/init.d/newrelic-sysmond" do
+      source "newrelic-sysmond.init.erb"
+      mode 0755
+    end
+
+    file "/etc/sysconfig/nrsysmond" do
+      content "NRSYSMOND_CONFIG=/etc/newrelic/nrsysmond.cfg\n"
+    end
+
+    directory "/var/log/newrelic/" do
+      action :create
+    end
+  else
+    package node['newrelic']['service_name'] do
+      action :install
+    end
+  end
+  #configure your New Relic license key
+  template "#{node['newrelic']['config_path']}/nrsysmond.cfg" do
+    source "nrsysmond.cfg.erb"
+    owner "root"
+    group node['newrelic']['config_file_group']
+    mode "640"
+    variables(
+      :license => node['newrelic']['server_monitoring']['license'],
+      :logfile => node['newrelic']['server_monitoring']['logfile'],
+      :loglevel => node['newrelic']['server_monitoring']['loglevel'],
+      :proxy => node['newrelic']['server_monitoring']['proxy'],
+      :ssl => node['newrelic']['server_monitoring']['ssl'],
+      :ssl_ca_path => node['newrelic']['server_monitoring']['ssl_ca_path'],
+      :ssl_ca_bundle => node['newrelic']['server_monitoring']['ssl_ca_bundle'],
+      :pidfile => node['newrelic']['server_monitoring']['pidfile'],
+      :collector_host => node['newrelic']['server_monitoring']['collector_host'],
+      :timeout => node['newrelic']['server_monitoring']['timeout']
+    )
+    notifies :restart, "service[#{node['newrelic']['service_name']}]"
+  end
+
+  service node['newrelic']['service_name'] do
+    supports :status => true, :start => true, :stop => true, :restart => true
+    action [:enable, :start] #starts the service if it's not running and enables it to start at system boot time
+  end
+when "windows"
         include_recipe node['newrelic']['dotnet_recipe']
-        
+
         if node['kernel']['machine'] == "x86_64"
                 windows_package "New Relic Server Monitor" do
                 source "http://download.newrelic.com/windows_server_monitor/release/NewRelicServerMonitor_x64_#{node['newrelic']['server_monitoring']['windows_version']}.msi"

--- a/templates/suse/newrelic-sysmond.init.erb
+++ b/templates/suse/newrelic-sysmond.init.erb
@@ -1,0 +1,283 @@
+#!/bin/sh
+#
+#     Template SUSE system startup script for example service/daemon newrelic-sysmond
+#     Copyright (C) 1995--2005  Kurt Garloff, SUSE / Novell Inc.
+#
+#     This library is free software; you can redistribute it and/or modify it
+#     under the terms of the GNU Lesser General Public License as published by
+#     the Free Software Foundation; either version 2.1 of the License, or (at
+#     your option) any later version.
+#
+#     This library is distributed in the hope that it will be useful, but
+#     WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#     Lesser General Public License for more details.
+#
+#     You should have received a copy of the GNU Lesser General Public
+#     License along with this library; if not, write to the Free Software
+#     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# /etc/init.d/newrelic-sysmond
+#   and its symbolic link
+# /(usr/)sbin/rcnewrelic-sysmond
+#
+# Template system startup script for some example service/daemon newrelic-sysmond
+#
+# LSB compatible service control script; see http://www.linuxbase.org/spec/
+#
+# Note: This template uses functions rc_XXX defined in /etc/rc.status on
+# UnitedLinux/SUSE/Novell based Linux distributions. If you want to base your
+# script on this template and ensure that it works on non UL based LSB
+#
+# compliant Linux distributions, you either have to provide the rc.status
+# functions from UL or change the script to work without them.
+# See skeleton.compat for a template that works with other distros as well.
+#
+### BEGIN INIT INFO
+# Provides:          newrelic-sysmond
+# Required-Start:    $syslog $remote_fs
+# Should-Start:      $time ypbind smtp
+# Required-Stop:     $syslog $remote_fs
+# Should-Stop:       ypbind smtp
+# Default-Start:     3 5
+# Default-Stop:      0 1 2 6
+# Short-Description: newrelic-sysmond XYZ daemon providing ZYX
+# Description:       Start newrelic-sysmond to allow XY and provide YZ
+#	continued on second line by '#<TAB>'
+#	should contain enough info for the runlevel editor
+#	to give admin some idea what this service does and
+#	what it's needed for ...
+#	(The Short-Description should already be a good hint.)
+### END INIT INFO
+#
+# Any extensions to the keywords given above should be preceeded by
+# X-VendorTag- (X-UnitedLinux- X-SuSE- for us) according to LSB.
+#
+# Notes on Required-Start/Should-Start:
+# * There are two different issues that are solved by Required-Start
+#    and Should-Start
+# (a) Hard dependencies: This is used by the runlevel editor to determine
+#     which services absolutely need to be started to make the start of
+#     this service make sense. Example: nfsserver should have
+#     Required-Start: $portmap
+#     Also, required services are started before the dependent ones.
+#     The runlevel editor will warn about such missing hard dependencies
+#     and suggest enabling. During system startup, you may expect an error,
+#     if the dependency is not fulfilled.
+# (b) Specifying the init script ordering, not real (hard) dependencies.
+#     This is needed by insserv to determine which service should be
+#     started first (and at a later stage what services can be started
+#     in parallel). The tag Should-Start: is used for this.
+#     It tells, that if a service is available, it should be started
+#     before. If not, never mind.
+# * When specifying hard dependencies or ordering requirements, you can
+#   use names of services (contents of their Provides: section)
+#   or pseudo names starting with a $. The following ones are available
+#   according to LSB (1.1):
+#	$local_fs		all local file systems are mounted
+#				(most services should need this!)
+#	$remote_fs		all remote file systems are mounted
+#				(note that /usr may be remote, so
+#				 many services should Require this!)
+#	$syslog			system logging facility up
+#	$network		low level networking (eth card, ...)
+#	$named			hostname resolution available
+#	$netdaemons		all network daemons are running
+#   The $netdaemons pseudo service has been removed in LSB 1.2.
+#   For now, we still offer it for backward compatibility.
+#   These are new (LSB 1.2):
+#	$time			the system time has been set correctly
+#	$portmap		SunRPC portmapping service available
+#   UnitedLinux extensions:
+#	$ALL			indicates that a script should be inserted
+#				at the end
+# * The services specified in the stop tags
+#   (Required-Stop/Should-Stop)
+#   specify which services need to be still running when this service
+#   is shut down. Often the entries there are just copies or a subset
+#   from the respective start tag.
+# * Should-Start/Stop are now part of LSB as of 2.0,
+#   formerly SUSE/Unitedlinux used X-UnitedLinux-Should-Start/-Stop.
+#   insserv does support both variants.
+# * X-UnitedLinux-Default-Enabled: yes/no is used at installation time
+#   (%fillup_and_insserv macro in %post of many RPMs) to specify whether
+#   a startup script should default to be enabled after installation.
+#   It's not used by insserv.
+#
+# Note on runlevels:
+# 0 - halt/poweroff 			6 - reboot
+# 1 - single user			2 - multiuser without network exported
+# 3 - multiuser w/ network (text mode)  5 - multiuser w/ network and X11 (xdm)
+#
+# Note on script names:
+# http://www.linuxbase.org/spec/refspecs/LSB_1.3.0/gLSB/gLSB/scrptnames.html
+# A registry has been set up to manage the init script namespace.
+# http://www.lanana.org/
+# Please use the names already registered or register one or use a
+# vendor prefix.
+
+NRSYSMOND_NAME="NewRelic System Monitor"
+
+# Check for missing binaries (stale symlinks should not happen)
+# Note: Special treatment of stop for LSB conformance
+NRSYSMOND_BIN=/usr/local/sbin/nrsysmond
+test -x $NRSYSMOND_BIN || { echo "$NRSYSMOND_BIN not installed";
+	if [ "$1" = "stop" ]; then exit 0;
+	else exit 5; fi; }
+
+# Check for existence of needed config file and read it
+NRSYSMOND_CONFIG=/etc/sysconfig/nrsysmond
+test -r $NRSYSMOND_CONFIG || { echo "$NRSYSMOND_CONFIG not existing";
+	if [ "$1" = "stop" ]; then exit 0;
+	else exit 6; fi; }
+
+# Read config
+. $NRSYSMOND_CONFIG
+
+# Source LSB init functions
+# providing start_daemon, killproc, pidofproc,
+# log_success_msg, log_failure_msg and log_warning_msg.
+# This is currently not used by UnitedLinux based distributions and
+# not needed for init scripts for UnitedLinux only. If it is used,
+# the functions from rc.status should not be sourced or used.
+#. /lib/lsb/init-functions
+
+# Shell functions sourced from /etc/rc.status:
+#      rc_check         check and set local and overall rc status
+#      rc_status        check and set local and overall rc status
+#      rc_status -v     be verbose in local rc status and clear it afterwards
+#      rc_status -v -r  ditto and clear both the local and overall rc status
+#      rc_status -s     display "skipped" and exit with status 3
+#      rc_status -u     display "unused" and exit with status 3
+#      rc_failed        set local and overall rc status to failed
+#      rc_failed <num>  set local and overall rc status to <num>
+#      rc_reset         clear both the local and overall rc status
+#      rc_exit          exit appropriate to overall rc status
+#      rc_active        checks whether a service is activated by symlinks
+. /etc/rc.status
+
+# Reset status of this service
+rc_reset
+
+# Return values acc. to LSB for all commands but status:
+# 0	  - success
+# 1       - generic or unspecified error
+# 2       - invalid or excess argument(s)
+# 3       - unimplemented feature (e.g. "reload")
+# 4       - user had insufficient privileges
+# 5       - program is not installed
+# 6       - program is not configured
+# 7       - program is not running
+# 8--199  - reserved (8--99 LSB, 100--149 distrib, 150--199 appl)
+#
+# Note that starting an already running service, stopping
+# or restarting a not-running service as well as the restart
+# with force-reload (in case signaling is not supported) are
+# considered a success.
+
+case "$1" in
+    start)
+	echo -n "Starting $NRSYSMOND_NAME"
+	## Start daemon with startproc(8). If this fails
+	## the return value is set appropriately by startproc.
+	/sbin/startproc $NRSYSMOND_BIN -c $NRSYSMOND_CONFIG
+
+	# Remember status and be verbose
+	rc_status -v
+	;;
+    stop)
+	echo -n "Shutting down $NRSYSMOND_NAME"
+	## Stop daemon with killproc(8) and if this fails
+	## killproc sets the return value according to LSB.
+
+	/sbin/killproc $NRSYSMOND_BIN
+
+	# Remember status and be verbose
+	rc_status -v
+	;;
+    try-restart|condrestart)
+	## Do a restart only if the service was active before.
+	## Note: try-restart is now part of LSB (as of 1.9).
+	## RH has a similar command named condrestart.
+	if test "$1" = "condrestart"; then
+		echo "${attn} Use try-restart ${done}(LSB)${attn} rather than condrestart ${warn}(RH)${norm}"
+	fi
+	$0 status
+	if test $? = 0; then
+		$0 restart
+	else
+		rc_reset	# Not running is not a failure.
+	fi
+	# Remember status and be quiet
+	rc_status
+	;;
+    restart)
+	## Stop the service and regardless of whether it was
+	## running or not, start it again.
+	$0 stop
+	$0 start
+
+	# Remember status and be quiet
+	rc_status
+	;;
+    force-reload)
+	## Signal the daemon to reload its config. Most daemons
+	## do this on signal 1 (SIGHUP).
+	## If it does not support it, restart the service if it
+	## is running.
+
+	echo -n "Reload service $NRSYSMOND_NAME"
+	## if it supports it:
+	/sbin/killproc -HUP $NRSYSMOND_BIN
+	#touch /var/run/NRSYSMOND.pid
+	rc_status -v
+
+	## Otherwise:
+	#$0 try-restart
+	#rc_status
+	;;
+    reload)
+	## Like force-reload, but if daemon does not support
+	## signaling, do nothing (!)
+
+	# If it supports signaling:
+	echo -n "Reload service $NRSYSMOND_NAME"
+	/sbin/killproc -HUP $NRSYSMOND_BIN
+	#touch /var/run/NRSYSMOND.pid
+	rc_status -v
+
+	## Otherwise if it does not support reload:
+	#rc_failed 3
+	#rc_status -v
+	;;
+    status)
+	echo -n "Checking for service NRSYSMOND "
+	## Check status with checkproc(8), if process is running
+	## checkproc will return with exit status 0.
+
+	# Return value is slightly different for the status command:
+	# 0 - service up and running
+	# 1 - service dead, but /var/run/  pid  file exists
+	# 2 - service dead, but /var/lock/ lock file exists
+	# 3 - service not running (unused)
+	# 4 - service status unknown :-(
+	# 5--199 reserved (5--99 LSB, 100--149 distro, 150--199 appl.)
+
+	# NOTE: checkproc returns LSB compliant status values.
+	/sbin/checkproc $NRSYSMOND_BIN
+	# NOTE: rc_status knows that we called this init script with
+	# "status" option and adapts its messages accordingly.
+	rc_status -v
+	;;
+    probe)
+	## Optional: Probe for the necessity of a reload, print out the
+	## argument to this init script which is required for a reload.
+	## Note: probe is not (yet) part of LSB (as of 1.9)
+	#test /etc/FOO/FOO.conf -nt /var/run/FOO.pid && echo reload
+	;;
+    *)
+	echo "Usage: $0 {start|stop|status|try-restart|restart|force-reload|reload|probe}"
+	exit 1
+	;;
+esac
+rc_exit


### PR DESCRIPTION
As mentionned in #43, this adds support for installation from tar.gz: I did this in order to support Suse, but it should be usable for other distros as well. The PHP Agent should even works on other platforms, but the Server Monitor package is Linux-only.
