### PR TITLE
use remote_file resource to download the Agent MSI installer package

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -33,10 +33,21 @@ platforms:
             service_name: httpd
           php_config: '/etc/php.d/newrelic.ini'
 
+#>>  - name: win-2012r2
+#>>    driver_config:
+#>>      box_url: https://wrock.ca.tier3.io/win2012r2-virtualbox.box
+#>>      communicator: winrm
+#>>      vm_hostname: false
+#>>      customize:
+#>>        usbehci: "off"
+#>>    transport:
+#>>      name: winrm
+
 suites:
   - name: default
     run_list:
       - recipe[newrelic::default]
+#>>    excludes: win-2012r2
     attributes:
       newrelic:
         license: '0000ffff0000ffff0000ffff0000ffff0000ffff'
@@ -55,3 +66,8 @@ suites:
     attributes:
       newrelic:
         license: '0000ffff0000ffff0000ffff0000ffff0000ffff'
+#>>  - name: dotnet_agent
+#>>    run_list:
+#>>      - recipe[newrelic::dotnet_agent]
+#>>    includes: win-2012r2
+

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -58,11 +58,13 @@ suites:
   - name: php-agent
     run_list:
       - "recipe[newrelic_lwrp_test::agent_php]"
+#>>    excludes: win-2012r2
     attributes:
       newrelic:
         license: '0000ffff0000ffff0000ffff0000ffff0000ffff'
   - name: server-monitor
     run_list: "recipe[newrelic_lwrp_test::server_monitor]"
+#>>    excludes: win-2012r2
     attributes:
       newrelic:
         license: '0000ffff0000ffff0000ffff0000ffff0000ffff'

--- a/recipes/dotnet_agent.rb
+++ b/recipes/dotnet_agent.rb
@@ -9,8 +9,15 @@ include_recipe 'newrelic::repository'
 
 license = NewRelic.application_monitoring_license(node)
 
-windows_package 'Install New Relic .NET Agent' do
+package_path = "#{Chef::Config[:file_cache_path]}/NewRelicDotNETAgentx64.msi"
+
+remote_file 'Download New Relic .NET Agent' do
+  path package_path
   source node['newrelic']['dotnet_agent']['https_download']
+end
+
+windows_package 'Install New Relic .NET Agent' do
+  source package_path
   options "/qb NR_LICENSE_KEY=#{license} INSTALLLEVEL=#{node['newrelic']['dotnet_agent']['install_level']}"
   installer_type :msi
   action node['newrelic']['dotnet_agent']['agent_action']

--- a/test/integration/dotnet_agent/serverspec/package_installed_spec.rb
+++ b/test/integration/dotnet_agent/serverspec/package_installed_spec.rb
@@ -1,0 +1,8 @@
+require 'serverspec'
+
+set :backend, :cmd
+set :os, :family => 'windows'
+
+describe package('New Relic .NET Agent (64-bit)') do
+  it { should be_installed }
+end


### PR DESCRIPTION
Apparently, in Chef 12, the source parameter can no longer be a url.

I've commented out the test-kitchen tests for the Windows box because:
- it needs test-kitchen 1.4.0.rc1,
- for some reason, the vagrant user needs to be logged in for the chef-omnibus installer to succeed.
