### PR TITLE
Implement attribute inclusion/override capabilty for attributes/default.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,17 +639,19 @@ end
 1. include `recipe[newrelic]` in a run list to implicly run `recipe[newrelic::server_monitor_agent]`  
 --- OR ---  
 include the bits and pieces explicitly in a run list:
-```ruby
-`recipe[newrelic::repository]`
-`recipe[newrelic::server_monitor_agent]`
-`recipe[newrelic::dotnet_agent]`
-`recipe[newrelic::java_agent]`
-`recipe[newrelic::nodejs_agent]`
-`recipe[newrelic::php_agent]`
-`recipe[newrelic::python_agent]`
-`recipe[newrelic::ruby_agent]`
-```
+	```ruby
+	`recipe[newrelic::repository]`
+	`recipe[newrelic::server_monitor_agent]`
+	`recipe[newrelic::dotnet_agent]`
+	`recipe[newrelic::java_agent]`
+	`recipe[newrelic::nodejs_agent]`
+	`recipe[newrelic::php_agent]`
+	`recipe[newrelic::python_agent]`
+	`recipe[newrelic::ruby_agent]`
+	```
 2. change the `node['newrelic']['license']` attribute to your New Relic license keys  
+--- OR ---  
+override the attributes from attributes/default.rb in attributes/customize.rb
 --- OR ---  
 override the attributes on a higher level (http://wiki.opscode.com/display/chef/Attributes#Attributes-AttributesPrecedence)
 

--- a/README.md
+++ b/README.md
@@ -637,23 +637,31 @@ end
 ## Usage
 
 1. include `recipe[newrelic]` in a run list to implicly run `recipe[newrelic::server_monitor_agent]`  
---- OR ---  
-include the bits and pieces explicitly in a run list:
-	```ruby
-	`recipe[newrelic::repository]`
-	`recipe[newrelic::server_monitor_agent]`
-	`recipe[newrelic::dotnet_agent]`
-	`recipe[newrelic::java_agent]`
-	`recipe[newrelic::nodejs_agent]`
-	`recipe[newrelic::php_agent]`
-	`recipe[newrelic::python_agent]`
-	`recipe[newrelic::ruby_agent]`
-	```
+  --- OR ---  
+  include the bits and pieces explicitly in a run list:
+```ruby
+recipe[newrelic::repository]
+recipe[newrelic::server_monitor_agent]
+recipe[newrelic::dotnet_agent]
+recipe[newrelic::java_agent]
+recipe[newrelic::nodejs_agent]
+recipe[newrelic::php_agent]
+recipe[newrelic::python_agent]
+recipe[newrelic::ruby_agent]
+```
 2. change the `node['newrelic']['license']` attribute to your New Relic license keys  
---- OR ---  
-override the attributes from attributes/default.rb in attributes/customize.rb
---- OR ---  
-override the attributes on a higher level (http://wiki.opscode.com/display/chef/Attributes#Attributes-AttributesPrecedence)
+  --- OR ---  
+  override attributes from `attributes/default.rb` in `attributes/customize.rb`:
+```ruby
+# attributes/default.rb
+default['newrelic']['license'] = nil
+```
+```ruby
+# attributes/customize.rb
+normal['newrelic']['license'] = 'yourlicensekeygoeshere'
+```
+  --- OR ---  
+  override the attributes on a higher level (http://wiki.opscode.com/display/chef/Attributes#Attributes-AttributesPrecedence)
 
 ## References
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -74,3 +74,5 @@ default['newrelic']['application_monitoring']['framework'] = nil
 default['newrelic']['application_monitoring']['webtransaction']['name']['remove_trailing_path'] = nil
 default['newrelic']['application_monitoring']['webtransaction']['name']['functions'] = nil
 default['newrelic']['application_monitoring']['webtransaction']['name']['files'] = nil
+
+include_attribute 'newrelic::customize'


### PR DESCRIPTION
Inspired by AWS OpsWorks.
For example: https://github.com/aws/opsworks-cookbooks/blob/release-chef-11.10/apache2/attributes/apache.rb

We had been using out-of-the-box newrelic cookbooks but needed to override the server-monitoring hostname dynamically (to include environment info, eg `prod`, `uat`, etc). Attribute overrides turned out to be cleaner/easier than another recipe.
