### PR TITLE
Ensure setting execute_php5enmod is meaningful

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -51,6 +51,16 @@ suites:
             - nothing
   - name: php-agent
     run_list: "recipe[newrelic_lwrp_test::agent_php]"
+    attributes:
+      newrelic:
+        php_agent:
+          execute_php5enmod: false
+  - name: php-agent-php5enmod
+    run_list: "recipe[newrelic_lwrp_test::agent_php]"
+    attributes:
+      newrelic:
+        php_agent:
+          execute_php5enmod: true
   - name: server-monitor
     run_list: "recipe[newrelic_lwrp_test::server_monitor]"
   - name: java-agent

--- a/providers/agent_php.rb
+++ b/providers/agent_php.rb
@@ -89,19 +89,17 @@ def webserver_service
 end
 
 def newrelic_php5enmod
-  execute_php5enmod = new_resource.execute_php5enmod ? 'true' : 'false'
   # run php5enmod newrelic
   execute 'newrelic-php5enmod' do
     command 'php5enmod newrelic'
     action :nothing
-    only_if execute_php5enmod
+    only_if { new_resource.execute_php5enmod }
   end
 end
 
 def generate_agent_config
   # configure New Relic INI file and set the daemon related options (documented at /usr/lib/newrelic-php5/scripts/newrelic.ini.template)
   # and reload/restart (determined by service_action) the web server in order to pick up the new settings
-  execute_php5enmod = new_resource.execute_php5enmod ? 'true' : 'false'
   template new_resource.config_file do
     cookbook new_resource.cookbook_ini
     source new_resource.source_ini
@@ -113,7 +111,7 @@ def generate_agent_config
     )
     sensitive true
     action :create
-    if execute_php5enmod
+    if new_resource.execute_php5enmod
       notifies :run, 'execute[newrelic-php5enmod]', :immediately
     end
     notifies new_resource.service_action, "service[#{new_resource.service_name}]", :delayed if new_resource.service_name

--- a/test/fixtures/cookbooks/newrelic_lwrp_test/recipes/agent_php.rb
+++ b/test/fixtures/cookbooks/newrelic_lwrp_test/recipes/agent_php.rb
@@ -13,5 +13,6 @@ newrelic_agent_php 'Install' do
   license node['newrelic']['license']
   service_name node['newrelic']['php_agent']['web_server']['service_name']
   config_file node['newrelic']['php_agent']['php_config']
+  execute_php5enmod node['newrelic']['php_agent']['execute_php5enmod']
   startup_mode 'external'
 end

--- a/test/integration/php-agent-php5enmod/serverspec/default_spec.rb
+++ b/test/integration/php-agent-php5enmod/serverspec/default_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe file('/etc/php5/apache2/conf.d/20-newrelic.ini'), :if => %w(debian ubuntu).include?(os[:family]) do
+  it { is_expected.to be_file }
+  it { is_expected.to be_symlink }
+  it { is_expected.to be_linked_to '../../mods-available/newrelic.ini' }
+end

--- a/test/integration/php-agent-php5enmod/serverspec/spec_helper.rb
+++ b/test/integration/php-agent-php5enmod/serverspec/spec_helper.rb
@@ -1,0 +1,3 @@
+require 'serverspec'
+
+set :backend, :exec


### PR DESCRIPTION
Prior to this, two instances of a variable assignment like so:

```ruby
execute_php5enmod = new_resource.execute_php5enmod ? 'true' : 'false'
```

would end up meaning that `execute_php5enmod` was always truthy.

I.e., `'false' == true` in Ruby

As the value is meant to be a boolean no matter what, and in the included recipe is cast to a boolean value, we should rely on its boolean-ness instead of always being true. In fact, the provider only allows boolean values, so there’s the validation.

Includes an additional test suite to validate this functionality.

Slightly unrelated, but I saw an opportunity to DRY up all the `spec_helper.rb` files, so I included that.