### PR TITLE
Allow configuration of the webserver_service

### DIFF
--- a/attributes/php_agent.rb
+++ b/attributes/php_agent.rb
@@ -10,6 +10,8 @@ default['newrelic']['php_agent']['install_silently'] = nil
 default['newrelic']['php_agent']['startup_mode'] = nil
 default['newrelic']['php_agent']['web_server']['service_name'] = nil
 default['newrelic']['php_agent']['web_server']['service_action'] = nil
+default['newrelic']['php_agent']['web_server']['service_provider'] = nil
+default['newrelic']['php_agent']['web_server']['service_supports'] =  {:status => true, :start => true, :stop => true, :restart => true, :reload => true}
 default['newrelic']['php_agent']['config_file'] = nil
 default['newrelic']['php_agent']['config_file_to_be_deleted'] = nil
 default['newrelic']['php_agent']['execute_php5enmod'] = nil

--- a/providers/agent_php.rb
+++ b/providers/agent_php.rb
@@ -84,7 +84,10 @@ end
 
 def webserver_service
   service new_resource.service_name do
-    supports :status => true, :start => true, :stop => true, :restart => true, :reload => true
+    supports new_resource.service_supports
+    if new_resource.service_provider
+      provider eval(new_resource.service_provider)
+    end
   end
 end
 

--- a/resources/agent_php.rb
+++ b/resources/agent_php.rb
@@ -17,6 +17,8 @@ attribute :install_silently, :kind_of => [TrueClass, FalseClass], :default => fa
 attribute :config_file_to_be_deleted, :kind_of => String, :default => nil
 attribute :service_name, :kind_of => String, :default => nil
 attribute :service_action, :kind_of => String, :default => 'restart'
+attribute :service_provider, :kind_of => String, :default => nil
+attribute :service_supports, :kind_of => Hash, :default => {:status => true, :start => true, :stop => true, :restart => true, :reload => true}
 attribute :execute_php5enmod, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :cookbook_ini, :kind_of => String, :default => 'newrelic'
 attribute :source_ini, :kind_of => String, :default => 'agent/php/newrelic.ini.erb'


### PR DESCRIPTION
This removes some assumptions on how the webserver_service is handled. In particular, I hit up against this case when using php5-fpm on Ubuntu 14.04 - I needed to be able to drop the "reload" action (it's not supported) as well as switch to using Upstart. 

