### PR TITLE
Add usage of Java agent_action attribute

### DIFF
--- a/providers/agent_java.rb
+++ b/providers/agent_java.rb
@@ -97,7 +97,7 @@ def install_newrelic
   end
   execute "newrelic_install_#{jar_file}" do
     cwd new_resource.install_dir
-    command "sudo java -jar newrelic.jar -s #{app_location} install"
+    command "sudo java -jar newrelic.jar -s #{app_location} #{new_resource.agent_action}"
     only_if { new_resource.execute_agent_action == true }
   end
 end

--- a/recipes/java_agent.rb
+++ b/recipes/java_agent.rb
@@ -46,5 +46,6 @@ newrelic_agent_java 'Install' do
   cross_application_tracer_enable NewRelic.to_boolean(node['newrelic']['application_monitoring']['cross_application_tracer']['enable']) unless node['newrelic']['application_monitoring']['cross_application_tracer']['enable'].nil?
   thread_profiler_enable NewRelic.to_boolean(node['newrelic']['application_monitoring']['thread_profiler']['enable']) unless node['newrelic']['application_monitoring']['thread_profiler']['enable'].nil?
   labels node['newrelic']['application_monitoring']['labels'] unless node['newrelic']['application_monitoring']['labels'].nil?
+  agent_action node['newrelic']['java_agent']['agent_action'] unless node['newrelic']['java_agent']['agent_action'].nil?
   execute_agent_action node['newrelic']['java_agent']['execute_agent_action'] unless node['newrelic']['java_agent']['execute_agent_action'].nil?
 end

--- a/resources/agent_java.rb
+++ b/resources/agent_java.rb
@@ -10,6 +10,7 @@ default_action :install
 attribute :license, :kind_of => String, :default => NewRelic.application_monitoring_license(node)
 attribute :version, :kind_of => String, :default => 'latest'
 attribute :install_dir, :kind_of => String, :default => '/opt/newrelic/java'
+attribute :agent_action, :kind_of => String, :default => 'install'
 attribute :execute_agent_action, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :app_location, :kind_of => String, :default => nil
 attribute :app_user, :kind_of => String, :default => 'newrelic'


### PR DESCRIPTION
The attribute exists, and is documented, but does nothing.

This updates the newrelic_java_agent LWRP & the accompanying recipe to take into account the `['newrelic']['java_agent']['agent_action']` attribute’s value.