### PR TITLE
Allow resources to skip repository install

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,9 @@ The `newrelic_server_monitor` resource will handle the requirements to configure
 
 #### Actions
 
-- :install -  will setup the New Relic repository, install and install package.  
-- :remove -  Uninstall the New Relic package
+- :install -  Setup the New Relic repository, and install package.
+- :configure -  Configure the installed package.
+- :remove -  Uninstall the New Relic package.
 
 #### Attribute parameters
 

--- a/providers/server_monitor.rb
+++ b/providers/server_monitor.rb
@@ -12,7 +12,6 @@ include NewRelic::ServerMonitorHelpers
 use_inline_resources if defined?(use_inline_resources)
 
 action :install do
-  check_license
   newrelic_repository
   case node['platform_family']
   when 'debian', 'rhel', 'fedora'
@@ -20,6 +19,17 @@ action :install do
   when 'windows'
     install_newrelic_service_windows
   end
+end
+
+action :configure do
+  check_license
+  case node['platform_family']
+  when 'debian', 'rhel', 'fedora'
+    configure_newrelic_service_linux
+  when 'windows'
+    # on Windows service creation/startup is done by the installer
+  end
+
 end
 
 action :remove do
@@ -35,7 +45,9 @@ def install_newrelic_service_linux
   package new_resource.service_name do
     action new_resource.action
   end
-  # configure your New Relic license key
+end
+
+def configure_newrelic_service_linux
   template "#{new_resource.config_path}/nrsysmond.cfg" do
     cookbook new_resource.cookbook
     source new_resource.source
@@ -74,7 +86,6 @@ def install_newrelic_service_windows
       checksum new_resource.windows32_checksum
     end
   end
-  # on Windows service creation/startup is done by the installer
 end
 
 def remove_newrelic_service_linux

--- a/resources/server_monitor.rb
+++ b/resources/server_monitor.rb
@@ -5,8 +5,8 @@
 # Copyright 2012-2015, Escape Studios
 #
 
-actions :install, :remove
-default_action :install
+actions :install, :configure, :remove
+default_action [:install, :configure]
 
 attribute :license, :kind_of => String, :default => NewRelic.server_monitoring_license(node)
 


### PR DESCRIPTION
Some restricted environments cannot add yum repositories, and must install newrelic manually. Would be great if there was a resource attribute flag that would allow the "install_repository" method to be skipped.

Would you be willing to accept a PR for this?