### PR TITLE
updated version constraint for apt cookbook to resolves the error 

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,7 @@ issues_url 'https://github.com/djoos-cookbooks/newrelic/issues' if respond_to?(:
 depends 'python'
 depends 'curl'
 depends 'apt'
-depends 'yum', '>= 3.0'
+depends 'yum'
 
 recipe 'newrelic', 'Adds the New Relic repository, installs & configures the New Relic server monitor agent.'
 recipe 'newrelic::repository', 'Adds the New Relic repository.'

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,7 @@ issues_url 'https://github.com/djoos-cookbooks/newrelic/issues' if respond_to?(:
 depends 'python'
 depends 'curl'
 depends 'apt'
-depends 'yum', '~> 3.0'
+depends 'yum', '>= 3.0'
 
 recipe 'newrelic', 'Adds the New Relic repository, installs & configures the New Relic server monitor agent.'
 recipe 'newrelic::repository', 'Adds the New Relic repository.'


### PR DESCRIPTION
Error Details :
Could not satisfy version constraints for: yum ; when the recipe is executed on latest version of Amazon Linux 2016.03
