### PR TITLE
Don't verify the agent configuration on every Chef run

### DIFF
--- a/providers/agent_python.rb
+++ b/providers/agent_python.rb
@@ -21,7 +21,6 @@ action :install do
   install_python_agent
   create_config_dir
   generate_agent_config
-  verify_agent_config
 end
 
 action :remove do
@@ -52,13 +51,6 @@ def generate_agent_config
     )
     sensitive true
     action :create
-  end
-end
-
-def verify_agent_config
-  virtualenv = "#{new_resource.virtualenv}/bin/" if new_resource.virtualenv
-  execute 'verify-python-agent' do
-    command "#{virtualenv}newrelic-admin validate-config #{new_resource.config_file}"
   end
 end
 

--- a/spec/unit/agent_python_spec.rb
+++ b/spec/unit/agent_python_spec.rb
@@ -28,10 +28,6 @@ describe 'newrelic_lwrp_test::agent_python' do
       expect(chef_run).to install_python_pip('newrelic')
     end
 
-    it 'execute verify python agent' do
-      expect(chef_run).to run_execute('newrelic-admin validate-config /etc/newrelic/newrelic.ini')
-    end
-
     it 'creates newrelic ini config template from newrelic.ini.erb' do
       expect(chef_run).to render_file('/etc/newrelic/newrelic.ini').with_content('0000ffff0000ffff0000ffff0000ffff0000ffff')
     end


### PR DESCRIPTION
We use the Python agent provider to setup NR on our application servers. Because the Python provider does a config verification, and we have Chef runs configured at 30 minute intervals, we constantly have a "Python Agent Test" application running in NR. Because this command is executed on every Chef run, we can't remove the NR application, and will be charged for it. See: https://docs.newrelic.com/docs/agents/python-agent/installation-configuration/testing-python-agent for more info on the agent test.

Because none of the other agent providers in this cookbook perform a verification step, I opted to just remove this code altogether rather than wrapping a resource guard around it.