### PR TITLE
adding other_options to server_monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Make sure you run Chef >= 0.10.0.
 * `node['newrelic']['server_monitoring']['pidfile']`
 * `node['newrelic']['server_monitoring']['collector_host']`
 * `node['newrelic']['server_monitoring']['timeout']`
+* `node['newrelic']['server_monitoring']['other_options']`
 
 * `node['newrelic']['application_monitoring']['enabled']`
 * `node['newrelic']['application_monitoring']['logfile']`
@@ -232,6 +233,7 @@ The `newrelic_server_monitor` resource will handle the requirements to configure
 * `'pidfile'` - defaults to nil
 * `'collector_host'` - defaults to nil
 * `'timeout'` - defaults to nil
+* `'other_options'` - defaults to empty Hash
 * `'alert_policy_id'` - defaults to nil
 
 #### Example

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,6 +32,7 @@ default['newrelic']['server_monitoring']['hostname'] = nil
 default['newrelic']['server_monitoring']['pidfile'] = nil
 default['newrelic']['server_monitoring']['collector_host'] = nil
 default['newrelic']['server_monitoring']['timeout'] = nil
+default['newrelic']['server_monitoring']['other_options'] = {}
 
 # application monitoring
 default['newrelic']['application_monitoring']['enabled'] = nil

--- a/recipes/server_monitor_agent.rb
+++ b/recipes/server_monitor_agent.rb
@@ -18,6 +18,7 @@ newrelic_server_monitor 'Install' do
   pidfile node['newrelic']['server_monitoring']['pidfile'] unless node['newrelic']['server_monitoring']['pidfile'].nil?
   collector_host node['newrelic']['server_monitoring']['collector_host'] unless node['newrelic']['server_monitoring']['collector_host'].nil?
   timeout node['newrelic']['server_monitoring']['timeout'] unless node['newrelic']['server_monitoring']['timeout'].nil?
+  other_options node['newrelic']['server_monitoring']['other_options'] unless node['newrelic']['server_monitoring']['other_options'].nil?
   alert_policy_id node['newrelic']['server_monitoring']['alert_policy_id'] unless node['newrelic']['server_monitoring']['alert_policy_id'].nil?
   config_file_user node['newrelic']['server_monitor_agent']['config_file_user'] unless node['newrelic']['server_monitor_agent']['config_file_user'].nil?
   config_file_group node['newrelic']['server_monitor_agent']['config_file_group'] unless node['newrelic']['server_monitor_agent']['config_file_group'].nil?

--- a/resources/server_monitor.rb
+++ b/resources/server_monitor.rb
@@ -21,6 +21,7 @@ attribute :labels, :kind_of => String, :default => nil
 attribute :pidfile, :kind_of => String, :default => nil
 attribute :collector_host, :kind_of => String, :default => nil
 attribute :timeout, :kind_of => String, :default => nil
+attribute :other_options, :kind_of => Hash, :default => {}
 attribute :alert_policy_id, :kind_of => String, :default => nil
 
 attribute :config_file_user, :kind_of => String, :default => 'root'

--- a/templates/default/agent/server_monitor/nrsysmond.cfg.erb
+++ b/templates/default/agent/server_monitor/nrsysmond.cfg.erb
@@ -191,3 +191,13 @@ collector_host=<%= @resource.collector_host %>
 <% else %>
 timeout=<%= @resource.timeout %>
 <% end %>
+
+#
+# Other Options : refer to the newrelic documentation for the details
+# https://docs.newrelic.com/docs/servers/new-relic-servers-linux/installation-configuration/linux-configuration-new-relic-servers
+#
+<% unless @resource.other_options.empty? %>
+<% @resource.other_options.each do | op_key, op_value | %>
+<%= op_key %>=<%= op_value %>
+<% end %>
+<% end %>


### PR DESCRIPTION
adding a new option to server_monitor so that users can add more configurations like "disable_nfs"