### PR TITLE
fix missing tags in python/newrelic.ini.erb template

### DIFF
--- a/templates/default/agent/python/newrelic.ini.erb
+++ b/templates/default/agent/python/newrelic.ini.erb
@@ -259,5 +259,5 @@ cross_application_tracer.enabled = <%= @resource.cross_application_tracer_enable
 # Feature flag
 # eg. use for improved Tornado instrumentation
 # (https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-232028)
-feature_flag = @resource.feature_flag
+feature_flag = <%= @resource.feature_flag %>
 <% end %>


### PR DESCRIPTION
Looks like the `newrelic.ini` template for Python is missing some expression-printing tags around the feature_flag attribute. Without these tags, the cookbook dumps `@resource.feature_flag` into the actual rendered file, causing the Newrelic Python Agent to complain.