### PR TITLE
Multiple application names for windows

### DIFF
--- a/templates/default/agent/dotnet/newrelic.config.erb
+++ b/templates/default/agent/dotnet/newrelic.config.erb
@@ -36,7 +36,9 @@
     fileName="<%= @resource.log_file_name %>" />
 
   <application disableSamplers="<%= @resource.app_disable_samplers %>">
-    <name><%= @resource.app_name %></name>
+  	<% @resource.app_name.split(';').first(3).each do |app_name|%>
+    <name><%= app_name %></name>
+    <% end %>
   </application>
 
   <instrumentation log="<%= @resource.instrumentation_log_enable %>">

--- a/test/fixtures/cookbooks/newrelic_lwrp_test/recipes/agent_dotnet.rb
+++ b/test/fixtures/cookbooks/newrelic_lwrp_test/recipes/agent_dotnet.rb
@@ -8,4 +8,5 @@
 
 newrelic_agent_dotnet 'Install' do
   license node['newrelic']['license']
+  app_name 'My Application;Sub Application'
 end


### PR DESCRIPTION
According to the [New Relic documentation](https://docs.newrelic.com/docs/agents/manage-apm-agents/app-naming/use-multiple-names-app#rollup), Applications can be reported to up to 3 application names. This functionality is easily done within the linux based recipes , but seems to be missing in the windows based recipes. This is a needed feature that we can't take advantage of unless we bypass the windows newrelic.config.erb template file.

This pull request updates the newrelic.config.erb file for windows to allow multiple application names to be provided in the same manner as with the java yaml configuration. Applications will be separated by the `;` character. This also limits to the first 3 application names given as new relic will not report to more than three applications.