### PR TITLE
adding logic for repository proxy for rhel

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ Make sure you run Chef >= 0.10.0.
 ### repository.rb:
 
 * `node['newrelic']['repository']['key']` - URL to the New Relic repository key, defaults to "http://download.newrelic.com/548C16BF.gpg"
+* `node['newrelic']['repository']['proxy']` - Repository proxy host, defaults to nil
+* `node['newrelic']['repository']['proxy_username']` - Repository proxy username, defaults to nil
+* `node['newrelic']['repository']['proxy_password']` - Repository proxy password, defaults to nil
 
 ### python_agent.rb:
 

--- a/attributes/repository.rb
+++ b/attributes/repository.rb
@@ -14,4 +14,7 @@ when 'debian'
   default['newrelic']['repository']['components'] = ['non-free']
 when 'rhel', 'fedora'
   default['newrelic']['repository']['uri'] = 'http://download.newrelic.com/pub/newrelic/el5/$basearch/'
+  default['newrelic']['repository']['proxy'] = node['newrelic']['proxy']
+  default['newrelic']['repository']['proxy_username'] = nil
+  default['newrelic']['repository']['proxy_password'] = nil
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -31,6 +31,9 @@ module NewRelic
         baseurl node['newrelic']['repository']['uri']
         gpgkey node['newrelic']['repository']['key']
         sslverify node['newrelic']['repository']['ssl_verify']
+        proxy node['newrelic']['repository']['proxy'] unless node['newrelic']['repository']['proxy'].nil?
+        proxy_username node['newrelic']['repository']['proxy_username'] unless node['newrelic']['repository']['proxy_username'].nil?
+        proxy_password node['newrelic']['repository']['proxy_password'] unless node['newrelic']['repository']['proxy_password'].nil?
       end
     end
 

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -19,5 +19,8 @@ when 'rhel', 'fedora'
     baseurl node['newrelic']['repository']['uri']
     gpgkey node['newrelic']['repository']['key']
     sslverify node['newrelic']['repository']['ssl_verify']
+    proxy node['newrelic']['repository']['proxy'] unless node['newrelic']['repository']['proxy'].nil?
+    proxy_username node['newrelic']['repository']['proxy_username'] unless node['newrelic']['repository']['proxy_username'].nil?
+    proxy_password node['newrelic']['repository']['proxy_password'] unless node['newrelic']['repository']['proxy_password'].nil?
   end
 end


### PR DESCRIPTION
updates to =>
README.md
attributes/repository.rb
libraries/helpers.rb
recipes/repository.rb

adds logic for the newrelic repository to utilize yum_repository proxy ability. apt_repository does not have an equivalent 