### PR TITLE
Fix support for Amazon Linux

### DIFF
--- a/attributes/repository.rb
+++ b/attributes/repository.rb
@@ -12,7 +12,7 @@ when 'debian'
   default['newrelic']['repository']['uri'] = 'http://download.newrelic.com/debian/'
   default['newrelic']['repository']['distribution'] = 'newrelic'
   default['newrelic']['repository']['components'] = ['non-free']
-when 'rhel', 'fedora'
+when 'rhel', 'fedora', 'amazon'
   default['newrelic']['repository']['uri'] = 'http://download.newrelic.com/pub/newrelic/el5/$basearch/'
 end
 
@@ -24,15 +24,12 @@ when 'debian'
   default['newrelic']['repository']['infrastructure']['uri'] = 'https://download.newrelic.com/infrastructure_agent/linux/apt'
   default['newrelic']['repository']['infrastructure']['components'] = ['main']
 when 'rhel', 'fedora'
-  case node['platform']
-  when 'amazon'
-    case node['platform_version'].to_i
-    when 2013, 2014, 2015, 2016, 2017
-      rhel_version = 6
-    end
-  else
-    rhel_version = node['platform_version'].to_i
+  rhel_version = node['platform_version'].to_i
+  default['newrelic']['repository']['infrastructure']['uri'] = "https://download.newrelic.com/infrastructure_agent/linux/yum/el/#{rhel_version}/x86_64"
+when 'amazon'
+  case node['platform_version'].to_i
+  when 2013, 2014, 2015, 2016, 2017
+    rhel_version = 6
   end
-
   default['newrelic']['repository']['infrastructure']['uri'] = "https://download.newrelic.com/infrastructure_agent/linux/yum/el/#{rhel_version}/x86_64"
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -16,8 +16,12 @@ module NewRelic
     end
 
     def install_newrelic_repo
-      install_newrelic_repo_debian if node['platform_family'] == 'debian'
-      install_newrelic_repo_rhel if node['platform_family'] == ('rhel' || 'fedora')
+      case node['platform_family']
+      when 'debian'
+        install_newrelic_repo_debian
+      when 'rhel', 'fedora', 'amazon'
+        install_newrelic_repo_rhel
+      end
     end
 
     def install_newrelic_repo_debian
@@ -39,8 +43,12 @@ module NewRelic
     end
 
     def install_newrelic_repo_infrastructure
-      install_newrelic_repo_infrastructure_debian if node['platform_family'] == 'debian'
-      install_newrelic_repo_infrastructure_rhel if node['platform_family'] == ('rhel' || 'fedora')
+      case node['platform_family']
+      when 'debian'
+        install_newrelic_repo_infrastructure_debian
+      when 'rhel', 'fedora', 'amazon'
+        install_newrelic_repo_infrastructure_rhel
+      end
     end
 
     def install_newrelic_repo_infrastructure_debian

--- a/providers/agent_infrastructure.rb
+++ b/providers/agent_infrastructure.rb
@@ -18,7 +18,7 @@ action :install do
   check_license
   newrelic_repository_infrastructure
   case node['platform_family']
-  when 'debian', 'rhel'
+  when 'debian', 'rhel', 'amazon'
     install_newrelic_infrastructure_service_linux
   when 'windows'
     install_newrelic_infrastructure_service_windows

--- a/providers/server_monitor.rb
+++ b/providers/server_monitor.rb
@@ -15,7 +15,7 @@ action :install do
   check_license
   newrelic_repository
   case node['platform_family']
-  when 'debian', 'rhel', 'fedora'
+  when 'debian', 'rhel', 'fedora', 'amazon'
     install_newrelic_service_linux
   when 'windows'
     install_newrelic_service_windows
@@ -24,7 +24,7 @@ end
 
 action :remove do
   case node['platform_family']
-  when 'debian', 'rhel', 'fedora'
+  when 'debian', 'rhel', 'fedora', 'amazon'
     remove_newrelic_service_linux
   when 'windows'
     remove_newrelic_service_windows

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -13,7 +13,7 @@ when 'debian'
     components node['newrelic']['repository']['components']
     key node['newrelic']['repository']['key']
   end
-when 'rhel', 'fedora'
+when 'rhel', 'fedora', 'amazon'
   yum_repository 'newrelic' do
     description 'New Relic packages for Enterprise Linux 5 - $basearch'
     baseurl node['newrelic']['repository']['uri']


### PR DESCRIPTION
Fixed support for Amazon Linux in Chef 13.
`platform_family` of Amazon Linux is judged as `amazon` in Chef 13, so this recipe skipped some processes, and could not install newrelic.