### PR TITLE
Support attributes parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ Make sure you run Chef >= 0.10.0.
 * `node['newrelic']['server_monitoring']['timeout']`
 * `node['newrelic']['server_monitoring']['other_options']`
 
+* `node['newrelic']['application_monitoring']['attributes']['enabled']`
+* `node['newrelic']['application_monitoring']['attributes']['exclude']`
+* `node['newrelic']['application_monitoring']['attributes']['include']`
 * `node['newrelic']['application_monitoring']['enabled']`
 * `node['newrelic']['application_monitoring']['logfile']`
 * `node['newrelic']['application_monitoring']['logfile_path']`

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,6 +35,9 @@ default['newrelic']['server_monitoring']['timeout'] = nil
 default['newrelic']['server_monitoring']['other_options'] = {}
 
 # application monitoring
+default['newrelic']['application_monitoring']['attributes']['enabled'] = true
+default['newrelic']['application_monitoring']['attributes']['exclude'] = nil
+default['newrelic']['application_monitoring']['attributes']['include'] = nil
 default['newrelic']['application_monitoring']['enabled'] = nil
 default['newrelic']['application_monitoring']['logfile'] = nil
 default['newrelic']['application_monitoring']['logfile_path'] = nil

--- a/libraries/newrelic.rb
+++ b/libraries/newrelic.rb
@@ -19,4 +19,8 @@ module NewRelic
       variable == 'true' || variable == 1
     end
   end
+
+  def self.string_to_array(str, delimiter = ',')
+    str.nil? ? [] : str.split(delimiter)
+  end
 end

--- a/resources/agent_dotnet.rb
+++ b/resources/agent_dotnet.rb
@@ -5,6 +5,8 @@
 # Copyright (c) 2016, David Joos
 #
 
+include NewRelic::Helpers
+
 actions :install, :remove
 default_action :install
 
@@ -45,9 +47,9 @@ attribute :app_disable_samplers, :kind_of => [TrueClass, FalseClass], :default =
 attribute :instrumentation_applications, :kind_of => Array, :default => []
 attribute :instrumentation_log_enable, :kind_of => [TrueClass, FalseClass], :default => false
 
-attribute :attributes_collection_enabled, :kind_of => [TrueClass, FalseClass], :default => true
-attribute :attributes_exclude, :kind_of => Array, :default => []
-attribute :attributes_include, :kind_of => Array, :default => []
+attribute :attributes_collection_enabled, :kind_of => [TrueClass, FalseClass], :default => node['newrelic']['application_monitoring']['attributes']['enabled']
+attribute :attributes_exclude, :kind_of => Array, :default => NewRelic.string_to_array(node['newrelic']['application_monitoring']['attributes']['exclude'])
+attribute :attributes_include, :kind_of => Array, :default => NewRelic.string_to_array(node['newrelic']['application_monitoring']['attributes']['include'])
 
 attribute :app_pools, :kind_of => Array, :default => [] # [{name: '', instrument: true|false}]
 attribute :app_pools_instrument_default_behavior, :kind_of => [TrueClass, FalseClass], :default => false

--- a/resources/agent_java.rb
+++ b/resources/agent_java.rb
@@ -19,6 +19,9 @@ attribute :agent_type, :kind_of => String, :default => 'java'
 attribute :template_cookbook, :kind_of => String, :default => 'newrelic'
 attribute :template_source, :kind_of => String, :default => 'agent/newrelic.yml.erb'
 
+attribute :attributes_collection_enabled, :kind_of => [TrueClass, FalseClass], :default => node['newrelic']['application_monitoring']['attributes']['enabled']
+attribute :attributes_exclude, :kind_of => String, :default => node['newrelic']['application_monitoring']['attributes']['exclude']
+attribute :attributes_include, :kind_of => String, :default => node['newrelic']['application_monitoring']['attributes']['include']
 attribute :enabled, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :app_name, :kind_of => String, :default => nil
 attribute :high_security, :kind_of => [TrueClass, FalseClass], :default => false

--- a/resources/agent_ruby.rb
+++ b/resources/agent_ruby.rb
@@ -17,6 +17,9 @@ attribute :audit_mode, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :template_cookbook, :kind_of => String, :default => 'newrelic'
 attribute :template_source, :kind_of => String, :default => 'agent/newrelic.yml.erb'
 
+attribute :attributes_collection_enabled, :kind_of => [TrueClass, FalseClass], :default => node['newrelic']['application_monitoring']['attributes']['enabled']
+attribute :attributes_exclude, :kind_of => String, :default => node['newrelic']['application_monitoring']['attributes']['exclude']
+attribute :attributes_include, :kind_of => String, :default => node['newrelic']['application_monitoring']['attributes']['include']
 attribute :enabled, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :app_name, :kind_of => String, :default => nil
 attribute :high_security, :kind_of => [TrueClass, FalseClass], :default => false

--- a/resources/yml.rb
+++ b/resources/yml.rb
@@ -47,3 +47,6 @@ attribute :browser_monitoring_auto_instrument, :default => node['newrelic']['app
 attribute :cross_application_tracer_enable, :default => node['newrelic']['application_monitoring']['browser_monitoring']['auto_instrument']
 attribute :thread_profiler_enable, :default => node['newrelic']['application_monitoring']['thread_profiler']['enable']
 attribute :labels, :default => node['newrelic']['application_monitoring']['labels']
+attribute :attributes_collection_enabled, :kind_of => [TrueClass, FalseClass], :default => node['newrelic']['application_monitoring']['attributes']['enabled']
+attribute :attributes_exclude, :kind_of => String, :default => node['newrelic']['application_monitoring']['attributes']['exclude']
+attribute :attributes_include, :kind_of => String, :default => node['newrelic']['application_monitoring']['attributes']['include']

--- a/templates/default/agent/newrelic.yml.erb
+++ b/templates/default/agent/newrelic.yml.erb
@@ -372,6 +372,24 @@ common: &default_settings
     # Default is true.
     enabled: true
 
+  # Attributes are key-value pairs containing information that determines the properties of an event or transaction.
+  # These key-value pairs can be viewed within transaction traces in New Relic APM, traced errors in New Relic APM, transaction events in Insights, and page views in Insights.
+  # You can customize exactly which attributes will be sent to each of these destinations.
+  attributes:
+
+    # By default, capture of attributes in New Relic is enabled.
+    enabled: <%= @resource.attributes_collection_enabled %>
+
+    <% unless @resource.attributes_exclude.nil? %>
+    # Prefix of attributes to exclude from all destinations. Allows * as wildcard at end.
+    exclude: [<%= @resource.attributes_exclude %>]
+    <% end %>
+
+    <% unless @resource.attributes_include.nil? %>
+    # Prefix of attributes to include from all destinations. Allows * as wildcard at end. Sample for Resque job attributes is 'job.resque.args.*'
+    include: [<%= @resource.attributes_include %>]
+    <% end %>
+
 # Application Environments
 # ------------------------------------------
 # Environment specific settings are in this section.


### PR DESCRIPTION
This supports extra parameters for attributes collection for the [Ruby agent](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration) and [Java agent](https://docs.newrelic.com/docs/agents/java-agent/configuration/java-agent-configuration-config-file), which take the same syntax for these parameters.

The functionality which already exists for the .NET agent is mimicked, with the exception that the .NET agent deployment now also supports the pass-by-attribute idiom for those parameters. The change _ should_ transparently roll forward, and I was able to verify this myself with a very synthetic test case (I don't have a Test Kitchen environment suitable for testing on Windows).