### PR TITLE
Make the default nil so we don't create an empty setting.

### DIFF
--- a/resources/agent_php.rb
+++ b/resources/agent_php.rb
@@ -47,7 +47,7 @@ attribute :ignored_params, :kind_of => String, :default => nil
 attribute :error_collector_enable, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :error_collector_record_database_errors, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :error_collector_prioritize_api_errors, :kind_of => [TrueClass, FalseClass], :default => false
-attribute :error_collector_ignore_errors, :kind_of => String, :default => ' '
+attribute :error_collector_ignore_errors, :kind_of => String, :default => nil
 attribute :browser_monitoring_auto_instrument, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :transaction_tracer_enable, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :transaction_tracer_threshold, :kind_of => String, :default => nil

--- a/templates/default/agent/php/newrelic.ini.erb
+++ b/templates/default/agent/php/newrelic.ini.erb
@@ -668,7 +668,7 @@ newrelic.high_security = <%= @resource.high_security %>
 ;          refer to See http://php.net/manual/en/errorfunc.constants.php
 ;
 <% if @resource.error_collector_ignore_errors.nil? %>
-;newrelic.error_collector.ignore_errors =
+;newrelic.error_collector.ignore_errors = 0
 <% else %>
 newrelic.error_collector.ignore_errors = <%= @resource.error_collector_ignore_errors %>
 <% end %>

--- a/templates/default/agent/php/newrelic.ini.erb
+++ b/templates/default/agent/php/newrelic.ini.erb
@@ -668,7 +668,7 @@ newrelic.high_security = <%= @resource.high_security %>
 ;          refer to See http://php.net/manual/en/errorfunc.constants.php
 ;
 <% if @resource.error_collector_ignore_errors.nil? %>
-;error_collector.ignore_errors =
+;newrelic.error_collector.ignore_errors =
 <% else %>
 newrelic.error_collector.ignore_errors = <%= @resource.error_collector_ignore_errors %>
 <% end %>


### PR DESCRIPTION
The default is empty string which ends up creating an empty
setting variable. This just tidies that up so we don't
create the setting unless its been explicitly defined.