### PR TITLE
Create newrelic user to fix java and ruby agent installation

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,11 @@ default['newrelic']['proxy'] = nil
 default['newrelic']['server_monitoring']['proxy'] = node['newrelic']['proxy']
 default['newrelic']['application_monitoring']['daemon']['proxy'] = node['newrelic']['proxy']
 
+# user
+default['newrelic']['user']['name'] = 'newrelic'
+default['newrelic']['user']['home'] = '/opt/newrelic'
+default['newrelic']['user']['shell'] = '/bin/false'
+
 #################
 # ADVANCED CONFIG
 #################

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -95,12 +95,13 @@ module NewRelic
     end
 
     def create_newrelic_user
+      return if node['etc']['passwd'][node['newrelic']['user']['name']]
       user node['newrelic']['user']['name'] do
         comment 'New Relic'
         shell node['newrelic']['user']['shell']
         home node['newrelic']['user']['home']
         manage_home true
-      end unless node['etc']['passwd'][node['newrelic']['user']['name']]
+      end
     end
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -93,5 +93,15 @@ module NewRelic
       return false unless ::File.exist?(dir)
       true
     end
+
+    def create_newrelic_user
+      user node['newrelic']['user']['name'] do
+        comment 'New Relic'
+        shell node['newrelic']['user']['shell']
+        home node['newrelic']['user']['home']
+        manage_home true
+        not_if "getent passwd #{node['newrelic']['user']['name']}"
+      end
+    end
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -100,8 +100,7 @@ module NewRelic
         shell node['newrelic']['user']['shell']
         home node['newrelic']['user']['home']
         manage_home true
-        not_if "getent passwd #{node['newrelic']['user']['name']}"
-      end
+      end unless node['etc']['passwd'][node['newrelic']['user']['name']]
     end
   end
 end

--- a/providers/agent_java.rb
+++ b/providers/agent_java.rb
@@ -15,6 +15,7 @@ use_inline_resources if defined?(use_inline_resources)
 action :install do
   # Check license key provided
   check_license
+  create_newrelic_user
   create_install_directory
   agent_jar
   generate_agent_config

--- a/providers/agent_ruby.rb
+++ b/providers/agent_ruby.rb
@@ -13,6 +13,7 @@ use_inline_resources if defined?(use_inline_resources)
 action :install do
   # Check license key provided
   check_license
+  create_newrelic_user
   create_install_directory
   install_newrelic
   generate_agent_config


### PR DESCRIPTION
As described in https://github.com/djoos-cookbooks/newrelic/issues/313, java and ruby agent installation fails because newrelic user does not exist. The user is created when you include `newrelic::server_monitor_agent` recipe but:
  a. you do not want to have server monitor agent installed in some cases
  b. it is being deprecated in favor of New Relic Infrastructure. The later does not create a separate user and runs as root.

To solve this, I attempt to create the user unless it already exist.