### PR TITLE
Repository attribute for java agent download

### DIFF
--- a/attributes/java_agent.rb
+++ b/attributes/java_agent.rb
@@ -9,6 +9,7 @@ default['newrelic']['java_agent']['version'] = 'latest'
 default['newrelic']['java_agent']['install_dir'] = '/opt/newrelic/java'
 default['newrelic']['java_agent']['app_user'] = 'newrelic'
 default['newrelic']['java_agent']['app_group'] = 'newrelic'
+default['newrelic']['java_agent']['repository'] = 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent'
 default['newrelic']['java_agent']['audit_mode'] = false
 default['newrelic']['java_agent']['log_file_count'] = 1
 default['newrelic']['java_agent']['log_limit_in_kbytes'] = 0

--- a/providers/agent_java.rb
+++ b/providers/agent_java.rb
@@ -51,12 +51,10 @@ def agent_jar
                "newrelic-java-#{new_resource.version}.zip"
              end
 
-  https_download = "https://download.newrelic.com/newrelic/java-agent/newrelic-agent/#{version}/#{filename}"
-
   cache_dir = Chef::Config[:file_cache_path]
 
   remote_file "#{new_resource.install_dir}/newrelic.zip" do
-    source https_download
+    source "#{new_resource.repository}/#{version}/#{filename}"
     user new_resource.app_user
     group new_resource.app_group
     mode '0664'

--- a/recipes/java_agent.rb
+++ b/recipes/java_agent.rb
@@ -9,6 +9,7 @@ newrelic_agent_java 'Install' do
   license NewRelic.application_monitoring_license(node)
   version node['newrelic']['java_agent']['version'] unless node['newrelic']['java_agent']['version'].nil?
   install_dir node['newrelic']['java_agent']['install_dir'] unless node['newrelic']['java_agent']['install_dir'].nil?
+  repository node['newrelic']['java_agent']['repository'] unless node['newrelic']['java_agent']['repository'].nil?
   app_location node['newrelic']['java_agent']['app_location'] unless node['newrelic']['java_agent']['app_location'].nil?
   template_cookbook node['newrelic']['java_agent']['template_cookbook'] unless node['newrelic']['java_agent']['template_cookbook'].nil?
   template_source node['newrelic']['java_agent']['template_source'] unless node['newrelic']['java_agent']['template_source'].nil?

--- a/resources/agent_java.rb
+++ b/resources/agent_java.rb
@@ -10,6 +10,7 @@ default_action :install
 attribute :license, :kind_of => String, :default => NewRelic.application_monitoring_license(node)
 attribute :version, :kind_of => String, :default => 'latest'
 attribute :install_dir, :kind_of => String, :default => '/opt/newrelic/java'
+attribute :repository, :kind_of => String, :default => 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent'
 attribute :agent_action, :kind_of => String, :default => 'install'
 attribute :execute_agent_action, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :app_location, :kind_of => String, :default => nil


### PR DESCRIPTION
Hello,

There are cases when you want to have more control over the source for downloading agent Zip (you are in a DMZ with no outbound access, download.newrelic.com is down, etc). This PR adds an attribute which allows an easy switch of the download repository.

https://github.com/djoos-cookbooks/newrelic/issues/295
https://github.com/djoos-cookbooks/newrelic/issues/311


