### PR TITLE
Adds error_collector.ignore_classes section for java agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ bin/*
 
 .kitchen/
 .kitchen.local.yml
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version (>= 2.11.0) of the newrelic cookbook.
 
+## v2.35.0
+- add error_collector_ignore_classes attribute for java_agent
+
 ## v2.34.0
 - allow custom attributes for infrastructure agent
 

--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ The `newrelic_agent_java` resource will handle the requirements to install java 
 * `'transaction_tracer_explain_threshold'` - Defaults to nil
 * `'error_collector_enable'` - Defaults to true
 * `'error_collector_ignore_errors'` - Defaults to nil
+* `'error_collector_ignore_classes'` - Defaults to nil
 * `'error_collector_ignore_status_codes'` - Defaults to nil
 * `'browser_monitoring_auto_instrument'` - Defaults to nil
 * `'cross_application_tracer_enable'` - Defaults to true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,6 +59,7 @@ default['newrelic']['application_monitoring']['labels'] = nil
 default['newrelic']['application_monitoring']['ignored_params'] = nil
 default['newrelic']['application_monitoring']['error_collector']['enable'] = nil
 default['newrelic']['application_monitoring']['error_collector']['ignore_errors'] = nil
+default['newrelic']['application_monitoring']['error_collector']['ignore_classes'] = nil
 default['newrelic']['application_monitoring']['error_collector']['ignore_status_codes'] = nil
 default['newrelic']['application_monitoring']['error_collector']['record_database_errors'] = nil
 default['newrelic']['application_monitoring']['error_collector']['prioritize_api_errors'] = nil

--- a/recipes/java_agent.rb
+++ b/recipes/java_agent.rb
@@ -41,6 +41,7 @@ newrelic_agent_java 'Install' do
   transaction_tracer_explain_threshold node['newrelic']['application_monitoring']['transaction_tracer']['explain_threshold'] unless node['newrelic']['application_monitoring']['transaction_tracer']['explain_threshold'].nil?
   error_collector_enable NewRelic.to_boolean(node['newrelic']['application_monitoring']['error_collector']['enable']) unless node['newrelic']['application_monitoring']['error_collector']['enable'].nil?
   error_collector_ignore_errors node['newrelic']['application_monitoring']['error_collector']['ignore_errors'] unless node['newrelic']['application_monitoring']['error_collector']['ignore_errors'].nil?
+  error_collector_ignore_classes node['newrelic']['application_monitoring']['error_collector']['ignore_classes'] unless node['newrelic']['application_monitoring']['error_collector']['ignore_classes'].nil?
   error_collector_ignore_status_codes node['newrelic']['application_monitoring']['error_collector']['ignore_status_codes'] unless node['newrelic']['application_monitoring']['error_collector']['ignore_status_codes'].nil?
   browser_monitoring_auto_instrument node['newrelic']['application_monitoring']['browser_monitoring']['auto_instrument'] unless node['newrelic']['application_monitoring']['browser_monitoring']['auto_instrument'].nil?
   cross_application_tracer_enable NewRelic.to_boolean(node['newrelic']['application_monitoring']['cross_application_tracer']['enable']) unless node['newrelic']['application_monitoring']['cross_application_tracer']['enable'].nil?

--- a/resources/agent_java.rb
+++ b/resources/agent_java.rb
@@ -48,6 +48,7 @@ attribute :transaction_tracer_slow_sql, :kind_of => String, :default => nil
 attribute :transaction_tracer_explain_threshold, :kind_of => String, :default => nil
 attribute :error_collector_enable, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :error_collector_ignore_errors, :kind_of => String, :default => nil
+attribute :error_collector_ignore_classes, :kind_of => Array, :default => nil
 attribute :error_collector_ignore_status_codes, :kind_of => String, :default => nil
 attribute :class_transformer_config, :kind_of => Hash, :default => {}
 attribute :browser_monitoring_auto_instrument, :kind_of => String, :default => nil

--- a/resources/agent_php.rb
+++ b/resources/agent_php.rb
@@ -48,6 +48,7 @@ attribute :error_collector_enable, :kind_of => [TrueClass, FalseClass], :default
 attribute :error_collector_record_database_errors, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :error_collector_prioritize_api_errors, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :error_collector_ignore_errors, :kind_of => String, :default => ' '
+attribute :error_collector_ignore_classes, :kind_of => Array, :default => nil
 attribute :browser_monitoring_auto_instrument, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :transaction_tracer_enable, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :transaction_tracer_threshold, :kind_of => String, :default => nil

--- a/resources/agent_python.rb
+++ b/resources/agent_python.rb
@@ -31,6 +31,7 @@ attribute :transaction_tracer_explain_threshold, :kind_of => String, :default =>
 attribute :thread_profiler_enable, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :error_collector_enable, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :error_collector_ignore_errors, :kind_of => String, :default => ' '
+attribute :error_collector_ignore_classes, :kind_of => Array, :default => nil
 attribute :browser_monitoring_auto_instrument, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :cross_application_tracer_enable, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :feature_flag, :kind_of => String, :default => nil

--- a/resources/agent_ruby.rb
+++ b/resources/agent_ruby.rb
@@ -46,6 +46,7 @@ attribute :transaction_tracer_slow_sql, :kind_of => String, :default => nil
 attribute :transaction_tracer_explain_threshold, :kind_of => String, :default => nil
 attribute :error_collector_enable, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :error_collector_ignore_errors, :kind_of => String, :default => nil
+attribute :error_collector_ignore_classes, :kind_of => Array, :default => nil
 attribute :error_collector_ignore_status_codes, :kind_of => String, :default => nil
 attribute :browser_monitoring_auto_instrument, :kind_of => String, :default => nil
 attribute :cross_application_tracer_enable, :kind_of => [TrueClass, FalseClass], :default => true

--- a/resources/yml.rb
+++ b/resources/yml.rb
@@ -42,6 +42,7 @@ attribute :transaction_tracer_slow_sql, :default => node['newrelic']['applicatio
 attribute :transaction_tracer_explain_threshold, :default => node['newrelic']['application_monitoring']['transaction_tracer']['explain_threshold']
 attribute :error_collector_enable, :default => node['newrelic']['application_monitoring']['error_collector']['enable']
 attribute :error_collector_ignore_errors, :default => node['newrelic']['application_monitoring']['error_collector']['ignore_errors']
+attribute :error_collector_ignore_classes, :default => node['newrelic']['application_monitoring']['error_collector']['ignore_classes']
 attribute :error_collector_ignore_status_codes, :default => node['newrelic']['application_monitoring']['error_collector']['ignore_status_codes']
 attribute :browser_monitoring_auto_instrument, :default => node['newrelic']['application_monitoring']['browser_monitoring']['auto_instrument']
 attribute :cross_application_tracer_enable, :default => node['newrelic']['application_monitoring']['browser_monitoring']['auto_instrument']

--- a/templates/default/agent/newrelic.yml.erb
+++ b/templates/default/agent/newrelic.yml.erb
@@ -289,6 +289,17 @@ common: &default_settings
     ignore_errors: <%= @resource.error_collector_ignore_errors %>
     <% end %>
 
+    # Specified exception class names will be ignored and will not affect error rate or Apdex score, or be reported to APM. Cannot be specified by system property.
+    # This setting is dynamic, so running agents will notice changes to newrelic.yml without a JVM restart.To stop specific Java exceptions from reporting to New Relic, set this property
+    #
+    # ignore_classes:
+    <% unless @resource.error_collector_ignore_classes.nil? %>
+    ignore_classes:
+      <% @resource.error_collector_ignore_classes.each do |ignore_class| -%>
+      - "<%= ignore_class %>"
+      <% end -%>
+    <% end %>
+
     # To stop specific http status codes from being reporting to New Relic as errors,
     # set this property to a comma separated list of status codes to ignore.
     # When this property is commented out it defaults to ignoring 404s.


### PR DESCRIPTION
Adds error_collector.ignore_classes section for java agent instead of deprecated error_collector.ignore_errors
https://docs.newrelic.com/docs/agents/java-agent/configuration/java-agent-configuration-config-file#ec-ignore_errors