### PR TITLE
Attribute to allow installing on-host integrations package

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,8 @@ The `newrelic_agent_infrastructure` resource will handle the requirements to set
 * `'logfile'` - To log to another location, provide a full path and file name, defaults to nil
 * `'verbose'` - Enables verbose logging for the agent, defaults to 0
 * `'proxy'` - Defaults to nil
+* `'custom_attributes'` - Sets key-value pairs (similar to tags in other tools) used to annotate the data from the Infrastructure agent, defaults to {}
+* `'on_host_integrations_enable'` - Installs New Relic Infrastructure on-host integration package, defaults to false
 * `'template_cookbook'` - Sets cookbook for template, defaults to 'newrelic'
 * `'template_source'` - Sets source for template, defaults to 'agent/infrastructure/newrelic.yml.erb'
 * `'service_actions'` - The New Relic infrastructure agent service actions, defaults to "`%w(enable start)`" (#starts the service if it's not running and enables it to start at system boot time)

--- a/providers/agent_infrastructure.rb
+++ b/providers/agent_infrastructure.rb
@@ -46,6 +46,13 @@ def install_newrelic_infrastructure_service_linux
     action new_resource.version unless new_resource.version.nil?
   end
 
+  # install the newrelic infrastructure on-host integration
+  if new_resource.on_host_integrations_enable
+    package 'newrelic-infra-integrations' do
+      action new_resource.action
+    end
+  end
+
   service_provider = linux_service_provider
 
   # setup newrelic infrastructure service

--- a/resources/agent_infrastructure.rb
+++ b/resources/agent_infrastructure.rb
@@ -16,6 +16,7 @@ attribute :logfile, :kind_of => String, :default => nil
 attribute :verbose, :kind_of => Integer, :default => 0
 attribute :proxy, :kind_of => String, :default => nil
 attribute :custom_attributes, :kind_of => Hash, :default => {}
+attribute :on_host_integrations_enable, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :template_cookbook, :kind_of => String, :default => 'newrelic'
 attribute :template_source, :kind_of => String, :default => 'agent/infrastructure/newrelic.yml.erb'
 attribute :service_actions, :kind_of => Array, :default => %w[enable start]

--- a/test/fixtures/cookbooks/newrelic_lwrp_test/recipes/agent_infrastructure.rb
+++ b/test/fixtures/cookbooks/newrelic_lwrp_test/recipes/agent_infrastructure.rb
@@ -5,4 +5,6 @@
 # Copyright (c) 2017, David Joos
 #
 
-newrelic_agent_infrastructure 'Install'
+newrelic_agent_infrastructure 'Install' do
+  on_host_integrations_enable true
+end

--- a/test/integration/infrastructure-agent/serverspec/default_spec.rb
+++ b/test/integration/infrastructure-agent/serverspec/default_spec.rb
@@ -7,6 +7,8 @@ end
 describe file('/etc/apt/sources.list.d/newrelic-infra.list'), :if => %w[debian ubuntu].include?(os[:family]) do
   it { is_expected.to be_file }
 end
-describe package 'newrelic-infra' do
-  it { is_expected.to be_installed }
+%w[newrelic-infra newrelic-infra-integrations].each do |pkg|
+  describe package pkg do
+    it { is_expected.to be_installed }
+  end
 end


### PR DESCRIPTION
Hello,

NR Infrastructure provides a list of on-host integrations through an extra package - https://docs.newrelic.com/docs/integrations/host-integrations/installation/install-host-integrations-built-new-relic

Added a new `on_host_integrations_enable ` attribute to `agent_infrastructure` resource to control it's installation.