### PR TITLE
added support for amazon linux 2018

### DIFF
--- a/attributes/repository.rb
+++ b/attributes/repository.rb
@@ -31,7 +31,7 @@ when 'rhel', 'fedora'
   default['newrelic']['repository']['infrastructure']['uri'] = "https://download.newrelic.com/infrastructure_agent/linux/yum/el/#{rhel_version}/x86_64"
 when 'amazon'
   case node['platform_version'].to_i
-  when 2013, 2014, 2015, 2016, 2017
+  when 2013, 2014, 2015, 2016, 2017, 2018
     rhel_version = 6
   end
   default['newrelic']['repository']['infrastructure']['uri'] = "https://download.newrelic.com/infrastructure_agent/linux/yum/el/#{rhel_version}/x86_64"


### PR DESCRIPTION
Amazon has released 2018 Amazon Linux AMI still based on REHL 6.  recipe fails as recipe no longer matches.  added the new filter