### PR TITLE
added distributed_tracing for java and ruby apm

### DIFF
--- a/resources/agent_java.rb
+++ b/resources/agent_java.rb
@@ -38,6 +38,7 @@ attribute :daemon_proxy_host, :kind_of => String, :default => nil
 attribute :daemon_proxy_port, :kind_of => String, :default => nil
 attribute :daemon_proxy_user, :kind_of => String, :default => nil
 attribute :daemon_proxy_password, :kind_of => String, :default => nil
+attribute :distributed_tracing_enable, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :capture_params, :kind_of => String, :default => nil
 attribute :ignored_params, :kind_of => String, :default => nil
 attribute :enable_custom_tracing, :kind_of => [TrueClass, FalseClass], :default => false

--- a/resources/agent_ruby.rb
+++ b/resources/agent_ruby.rb
@@ -35,6 +35,7 @@ attribute :daemon_proxy_host, :kind_of => String, :default => nil
 attribute :daemon_proxy_port, :kind_of => String, :default => nil
 attribute :daemon_proxy_user, :kind_of => String, :default => nil
 attribute :daemon_proxy_password, :kind_of => String, :default => nil
+attribute :distributed_tracing_enable, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :capture_params, :kind_of => String, :default => nil
 attribute :ignored_params, :kind_of => String, :default => nil
 attribute :enable_custom_tracing, :kind_of => [TrueClass, FalseClass], :default => false

--- a/templates/default/agent/newrelic.yml.erb
+++ b/templates/default/agent/newrelic.yml.erb
@@ -309,6 +309,17 @@ common: &default_settings
     ignore_status_codes: <%= @resource.error_collector_ignore_status_codes %>
     <% end %>
 
+  # Distributed tracing lets you see the path that a request takes through your distributed system.
+  # Enabling distributed tracing changes the behavior of some New Relic features, so carefully consult the transition
+  # guide before you enable this feature: https://docs.newrelic.com/docs/transition-guide-distributed-tracing
+  # Default is false.
+  distributed_tracing:
+    <%if @resource.distributed_tracing_enable.nil? %>
+    enabled: false
+    <% else %>
+    enabled: <%= @resource.distributed_tracing_enable %>
+    <% end %>
+
   # Cross Application Tracing adds request and response headers to
   # external calls using the Apache HttpClient libraries to provided better
   # performance data when calling applications monitored by other New Relic Agents.


### PR DESCRIPTION
Hello,

This allows enabling distributed tracing for java and ruby APMs - https://docs.newrelic.com/docs/apm/distributed-tracing/enable-configure/enable-distributed-tracing

Thanks,
Arcadie