### PR TITLE
Fixing newrelic_yml resource for distributed_tracing_enable

### DIFF
--- a/resources/yml.rb
+++ b/resources/yml.rb
@@ -31,6 +31,7 @@ attribute :daemon_proxy_host, :kind_of => String, :default => nil
 attribute :daemon_proxy_port, :kind_of => String, :default => nil
 attribute :daemon_proxy_user, :kind_of => String, :default => nil
 attribute :daemon_proxy_password, :kind_of => String, :default => nil
+attribute :distributed_tracing_enable, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :capture_params, :default => node['newrelic']['application_monitoring']['capture_params']
 attribute :ignored_params, :default => node['newrelic']['application_monitoring']['ignored_params']
 attribute :enable_custom_tracing, :kind_of => [TrueClass, FalseClass], :default => false


### PR DESCRIPTION
We use newrelic_yml in several of our cookbooks.  After updating to newrelic 2.39.0, we starting getting failures related to the recent feature addition of distributed tracing enabling.

Here's the error:

`      ================================================================================
      Error executing action `create` on resource 'template[/opt/newrelic/java/ir-newrelic.yml]'
      ================================================================================

      Chef::Mixin::Template::TemplateError
      ------------------------------------
      undefined method `distributed_tracing_enable' for Custom resource newrelic_yml from cookbook newrelic

      Resource Declaration:
      ---------------------
      suppressed sensitive resource output

      Compiled Resource:
      ------------------
      suppressed sensitive resource output

      Template Context:
      -----------------
      on line #317
      315:   # Default is false.
      316:   distributed_tracing:
      317:     <%if @resource.distributed_tracing_enable.nil? %>
      318:     enabled: false
      319:     <% else %>

      System Info:
      ------------
      chef_version=12.21.31
      platform=centos
      platform_version=6.9
      ruby=ruby 2.3.5p376 (2017-09-14 revision 59905) [x86_64-linux]
      program_name=chef-client worker: ppid=31845;start=12:14:13;
      executable=/opt/chef/bin/chef-client`

`    ================================================================================                                                                                                                                                                                                                                              Error executing action `generate` on resource 'newrelic_yml[/opt/newrelic/java/ir-newrelic.yml]'                                                                                                                                                                                                                              ================================================================================                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            Chef::Mixin::Template::TemplateError                                                                                                                                                                                                                                                                                          ------------------------------------                                                                                                                                                                                                                                                                                          undefined method `distributed_tracing_enable' for Custom resource newrelic_yml from cookbook newrelic
    Resource Declaration:                                                                                                                                                                                                                                                                                                         ---------------------                                                                                                                                                                                                                                                                                                         # In /var/chef/cache/cookbooks/REDACT/recipes/image_resizer.rb                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     32:   newrelic_yml '/opt/newrelic/java/ir-newrelic.yml' do                                                                                                                                                                                                                                                                    33:     agent_type 'java'                                                                                                                                                                                                                                                                                                     34:     app_name 'Image Resizer'                                                                                                                                                                                                                                                                                              35:     license vault['license']                                                                                                                                                                                                                                                                                              36:     log_daily true                                                                                                                                                                                                                                                                                                        37:   end
     38:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        Compiled Resource:                                                                                                                                                                                                                                                                                                            ------------------                                                                                                                                                                                                                                                                                                            # Declared in /var/chef/cache/cookbooks/REDACT/recipes/image_resizer.rb:32:in `from_file'
                                                                                                                                                                                                                                                                                                                                  newrelic_yml("/opt/newrelic/java/ir-newrelic.yml") do
      action [:generate]
      retries 0
      retry_delay 2
      default_guard_interpreter :default
      declared_type :newrelic_yml
      cookbook_name "REDACT"
      recipe_name "image_resizer"
      agent_type "java"
      app_name "Image Resizer"
      license "REDACT"
      log_daily true
      yml_path "/opt/newrelic/java/ir-newrelic.yml"
      template_cookbook "newrelic"
      template_source "agent/newrelic.yml.erb"
    end

    Template Context:
    -----------------
    on line #317
    315:   # Default is false.
    316:   distributed_tracing:
    317:     <%if @resource.distributed_tracing_enable.nil? %>
    318:     enabled: false
    319:     <% else %>

    System Info:
    ------------
    chef_version=12.21.31
    platform=centos
    platform_version=6.9
    ruby=ruby 2.3.5p376 (2017-09-14 revision 59905) [x86_64-linux]
    program_name=chef-client worker: ppid=31845;start=12:14:13;
    executable=/opt/chef/bin/chef-client`

This addition fixed the issue for us.