### PR TITLE
Missing Distributed Tracing attribute strapped into recipe

### DIFF
--- a/recipes/java_agent.rb
+++ b/recipes/java_agent.rb
@@ -32,6 +32,7 @@ newrelic_agent_java 'Install' do
   daemon_proxy_port node['newrelic']['application_monitoring']['daemon']['proxy_port'] unless node['newrelic']['application_monitoring']['daemon']['proxy_port'].nil?
   daemon_proxy_user node['newrelic']['application_monitoring']['daemon']['proxy_user'] unless node['newrelic']['application_monitoring']['daemon']['proxy_user'].nil?
   daemon_proxy_password node['newrelic']['application_monitoring']['daemon']['proxy_password'] unless node['newrelic']['application_monitoring']['daemon']['proxy_password'].nil?
+  distributed_tracing_enable node['newrelic']['java_agent']['distributed_tracing_enable'] unless node['newrelic']['java_agent']['distributed_tracing_enable'].nil?
   capture_params node['newrelic']['application_monitoring']['capture_params'] unless node['newrelic']['application_monitoring']['capture_params'].nil?
   ignored_params node['newrelic']['application_monitoring']['ignored_params'] unless node['newrelic']['application_monitoring']['ignored_params'].nil?
   transaction_tracer_enable node['newrelic']['application_monitoring']['transaction_tracer']['enable'] unless node['newrelic']['application_monitoring']['transaction_tracer']['enable'].nil?

--- a/recipes/ruby_agent.rb
+++ b/recipes/ruby_agent.rb
@@ -24,6 +24,7 @@ newrelic_agent_ruby 'Install' do
   log_daily node['newrelic']['ruby_agent']['log_daily'] unless node['newrelic']['ruby_agent']['log_daily']
   daemon_ssl NewRelic.to_boolean(node['newrelic']['application_monitoring']['daemon']['ssl']) unless node['newrelic']['application_monitoring']['daemon']['ssl']
   daemon_proxy node['newrelic']['application_monitoring']['daemon']['proxy'] unless node['newrelic']['application_monitoring']['daemon']['proxy']
+  distributed_tracing_enable node['newrelic']['ruby_agent']['distributed_tracing_enable'] unless node['newrelic']['ruby_agent']['distributed_tracing_enable'].nil?
   capture_params node['newrelic']['application_monitoring']['capture_params'] unless node['newrelic']['application_monitoring']['capture_params']
   ignored_params node['newrelic']['application_monitoring']['ignored_params'] unless node['newrelic']['application_monitoring']['ignored_params']
   transaction_tracer_enable node['newrelic']['application_monitoring']['transaction_tracer']['enable'] unless node['newrelic']['application_monitoring']['transaction_tracer']['enable']


### PR DESCRIPTION
Original PR #351 did not add attribute into the recipe for java and ruby agents to enable distributed tracing