### PR TITLE
Use upstart on ubuntu < 16.04 correctly

### DIFF
--- a/providers/agent_infrastructure.rb
+++ b/providers/agent_infrastructure.rb
@@ -76,6 +76,8 @@ def linux_service_provider
     if node['platform_version'] =~ /^6/
       service_provider = Chef::Provider::Service::Upstart
     end
+  end
+  case node['platform']
   when 'ubuntu'
     if node['platform_version'].to_f < 16.04
       service_provider = Chef::Provider::Service::Upstart


### PR DESCRIPTION
On ubuntu, the platform_family is listed as `debian`, but the platform is listed as `ubuntu`.  Since debian never defaulted to upstart, only ubuntu should get upstart, so it's not correct to switch on `debian`.