### PR TITLE
Fix infrastructure agent for Ubuntu and Amazon Linux

### DIFF
--- a/providers/agent_infrastructure.rb
+++ b/providers/agent_infrastructure.rb
@@ -76,6 +76,9 @@ def linux_service_provider
     if node['platform_version'] =~ /^6/
       service_provider = Chef::Provider::Service::Upstart
     end
+  end
+
+  case node['platform']
   when 'ubuntu'
     if node['platform_version'].to_f < 16.04
       service_provider = Chef::Provider::Service::Upstart

--- a/providers/agent_infrastructure.rb
+++ b/providers/agent_infrastructure.rb
@@ -69,7 +69,8 @@ def linux_service_provider
   # upstart workaround(s)
   case node['platform_family']
   when 'amazon'
-    if node['platform_version'].to_i == 1
+    # Amazon 1.x version format is 'YEAR.MONTH'
+    if node['platform_version'].to_i > 2000
       service_provider = Chef::Provider::Service::Upstart
     end
   when 'rhel'

--- a/spec/unit/agent_infrastructure_spec.rb
+++ b/spec/unit/agent_infrastructure_spec.rb
@@ -29,7 +29,67 @@ describe 'newrelic_lwrp_test::agent_infrastructure' do
     end
 
     it 'enables newrelic-infra service' do
-      expect(chef_run).to enable_service('newrelic-infra')
+      expect(chef_run).to enable_service('newrelic-infra').with(
+        :provider => Chef::Provider::Service::Upstart
+      )
     end
   end
+
+  context 'Ubuntu 14.04' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(:log_level => LOG_LEVEL, :platform => 'ubuntu', :version => '14.04', :step_into => ['newrelic_agent_infrastructure']) do |node|
+        stub_node_resources(node)
+      end.converge(described_recipe)
+    end
+
+    it 'enables newrelic-infra service with upstart' do
+      expect(chef_run).to enable_service('newrelic-infra').with(
+        :provider => Chef::Provider::Service::Upstart
+      )
+    end
+  end
+
+  context 'Ubuntu 16.04' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(:log_level => LOG_LEVEL, :platform => 'ubuntu', :version => '16.04', :step_into => ['newrelic_agent_infrastructure']) do |node|
+        stub_node_resources(node)
+      end.converge(described_recipe)
+    end
+
+    it 'enables newrelic-infra service with systemd' do
+        expect(chef_run).to enable_service('newrelic-infra').with(
+          :provider => Chef::Provider::Service::Systemd
+        )
+    end
+  end
+
+  context 'Amazon Linux' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(:log_level => LOG_LEVEL, :platform => 'amazon', :version => '2018.03', :step_into => ['newrelic_agent_infrastructure']) do |node|
+        stub_node_resources(node)
+      end.converge(described_recipe)
+    end
+
+    it 'enables newrelic-infra service with upstart' do
+        expect(chef_run).to enable_service('newrelic-infra').with(
+          :provider => Chef::Provider::Service::Upstart
+        )
+    end
+  end
+
+  context 'Amazon Linux 2' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(:log_level => LOG_LEVEL, :platform => 'amazon', :version => '2', :step_into => ['newrelic_agent_infrastructure']) do |node|
+        stub_node_resources(node)
+      end.converge(described_recipe)
+    end
+
+    it 'enables newrelic-infra service with systemd' do
+        expect(chef_run).to enable_service('newrelic-infra').with(
+          :provider => Chef::Provider::Service::Systemd
+        )
+    end
+  end
+
+  
 end


### PR DESCRIPTION
* Amazon Linux version detection was incorrect:
  * 1.x version is in "YEAR.MONTH" format
  * 2.x is 2.x
* Ubuntu platform was incorrectly detected

Added tests for both.

Fixes #352 and probably #343