### PR TITLE
support strip_command_line flag for the infra agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,7 @@ The `newrelic_agent_infrastructure` resource will handle the requirements to set
 * `'service_actions'` - The New Relic infrastructure agent service actions, defaults to "`%w(enable start)`" (#starts the service if it's not running and enables it to start at system boot time)
 * `'windows_version'` - the Windows version to install, defaults to "1.0.703"
 * `'windows_checksum'` - checksum of the (64-bit) Windows version, defaults to "3c9f98325dc484ee8735f01b913803eaef54f06641348b3dd9f3c0b3cd803ace"
+* `'strip_command_line'` - Undocumented boolean flag for the newrelic-infra.yml file, if set to false includes the parameters in the command line reported by the infrastructure agent. Defaults to nil, which defaults to false for the infrastructure agent.
 
 ### `newrelic_deployment`
 This cookbook includes an LWRP for notifying New Relic of a deployment

--- a/resources/agent_infrastructure.rb
+++ b/resources/agent_infrastructure.rb
@@ -22,3 +22,4 @@ attribute :template_source, :kind_of => String, :default => 'agent/infrastructur
 attribute :service_actions, :kind_of => Array, :default => %w[enable start]
 attribute :windows_version, :kind_of => String, :default => '1.0.703'
 attribute :windows_checksum, :kind_of => String, :default => '3c9f98325dc484ee8735f01b913803eaef54f06641348b3dd9f3c0b3cd803ace'
+attribute :strip_command_line, :kind_of => [TrueClass, FalseClass], :default => nil

--- a/templates/default/agent/infrastructure/newrelic.yml.erb
+++ b/templates/default/agent/infrastructure/newrelic.yml.erb
@@ -17,6 +17,9 @@ verbose: <%= @resource.verbose %>
 <% unless @resource.proxy.nil? -%>
 proxy: <%= @resource.proxy %>
 <% end -%>
+<% unless @resource.strip_command_line.nil? -%>
+strip_command_line: <%= @resource.strip_command_line %>
+<% end -%>
 <% unless @resource.custom_attributes.empty? -%>
 custom_attributes:
 <% @resource.custom_attributes.each do |attribute, value|%>


### PR DESCRIPTION
https://github.com/djoos-cookbooks/newrelic/issues/364

Undocumented boolean flag for the newrelic-infra.yml file, if set to false includes the parameters in the command line reported by the infrastructure agent. Defaults to nil, which defaults to false for the infrastructure agent.

Kinda tested locally, my Ruby is extremely limited.