### PR TITLE
lazy evaluation of default properties in yml.rb

### DIFF
--- a/resources/yml.rb
+++ b/resources/yml.rb
@@ -18,34 +18,34 @@ attribute :enabled, :kind_of => [TrueClass, FalseClass, String], :default => nil
 attribute :owner, :kind_of => String, :default => nil
 attribute :group, :kind_of => String, :default => nil
 attribute :license, :kind_of => String, :default => lazy { NewRelic.application_monitoring_license(node) }
-attribute :logfile, :kind_of => String, :default => node['newrelic']['application_monitoring']['logfile']
-attribute :logfile_path, :kind_of => String, :default => node['newrelic']['application_monitoring']['logfile']
-attribute :loglevel, :kind_of => String, :default => node['newrelic']['application_monitoring']['loglevel']
+attribute :logfile, :kind_of => String, :default => lazy { node['newrelic']['application_monitoring']['logfile'] }
+attribute :logfile_path, :kind_of => String, :default => lazy { node['newrelic']['application_monitoring']['logfile'] }
+attribute :loglevel, :kind_of => String, :default => lazy { node['newrelic']['application_monitoring']['loglevel'] }
 attribute :audit_mode, :kind_of => [TrueClass, FalseClass, String], :default => nil
 attribute :log_file_count, :default => nil
 attribute :log_limit_in_kbytes, :default => nil
 attribute :log_daily, :default => nil
-attribute :daemon_ssl, :default => node['newrelic']['application_monitoring']['daemon']['ssl']
-attribute :daemon_proxy, :default => node['newrelic']['application_monitoring']['daemon']['proxy']
+attribute :daemon_ssl, :default => lazy { node['newrelic']['application_monitoring']['daemon']['ssl'] }
+attribute :daemon_proxy, :default => lazy { node['newrelic']['application_monitoring']['daemon']['proxy'] }
 attribute :daemon_proxy_host, :kind_of => String, :default => nil
 attribute :daemon_proxy_port, :kind_of => String, :default => nil
 attribute :daemon_proxy_user, :kind_of => String, :default => nil
 attribute :daemon_proxy_password, :kind_of => String, :default => nil
 attribute :distributed_tracing_enable, :kind_of => [TrueClass, FalseClass], :default => false
-attribute :capture_params, :default => node['newrelic']['application_monitoring']['capture_params']
-attribute :ignored_params, :default => node['newrelic']['application_monitoring']['ignored_params']
+attribute :capture_params, :default => lazy { node['newrelic']['application_monitoring']['capture_params'] }
+attribute :ignored_params, :default => lazy { node['newrelic']['application_monitoring']['ignored_params'] }
 attribute :enable_custom_tracing, :kind_of => [TrueClass, FalseClass], :default => false
-attribute :transaction_tracer_enable, :default => node['newrelic']['application_monitoring']['transaction_tracer']['enable']
-attribute :transaction_tracer_threshold, :default => node['newrelic']['application_monitoring']['transaction_tracer']['threshold']
-attribute :transaction_tracer_record_sql, :default => node['newrelic']['application_monitoring']['transaction_tracer']['record_sql']
-attribute :transaction_tracer_stack_trace_threshold, :default => node['newrelic']['application_monitoring']['transaction_tracer']['stack_trace_threshold']
-attribute :transaction_tracer_slow_sql, :default => node['newrelic']['application_monitoring']['transaction_tracer']['slow_sql']
-attribute :transaction_tracer_explain_threshold, :default => node['newrelic']['application_monitoring']['transaction_tracer']['explain_threshold']
-attribute :error_collector_enable, :default => node['newrelic']['application_monitoring']['error_collector']['enable']
-attribute :error_collector_ignore_errors, :default => node['newrelic']['application_monitoring']['error_collector']['ignore_errors']
-attribute :error_collector_ignore_classes, :default => node['newrelic']['application_monitoring']['error_collector']['ignore_classes']
-attribute :error_collector_ignore_status_codes, :default => node['newrelic']['application_monitoring']['error_collector']['ignore_status_codes']
-attribute :browser_monitoring_auto_instrument, :default => node['newrelic']['application_monitoring']['browser_monitoring']['auto_instrument']
-attribute :cross_application_tracer_enable, :default => node['newrelic']['application_monitoring']['browser_monitoring']['auto_instrument']
-attribute :thread_profiler_enable, :default => node['newrelic']['application_monitoring']['thread_profiler']['enable']
-attribute :labels, :default => node['newrelic']['application_monitoring']['labels']
+attribute :transaction_tracer_enable, :default => lazy { node['newrelic']['application_monitoring']['transaction_tracer']['enable'] }
+attribute :transaction_tracer_threshold, :default => lazy { node['newrelic']['application_monitoring']['transaction_tracer']['threshold'] }
+attribute :transaction_tracer_record_sql, :default => lazy { node['newrelic']['application_monitoring']['transaction_tracer']['record_sql'] }
+attribute :transaction_tracer_stack_trace_threshold, :default => lazy { node['newrelic']['application_monitoring']['transaction_tracer']['stack_trace_threshold'] }
+attribute :transaction_tracer_slow_sql, :default => lazy { node['newrelic']['application_monitoring']['transaction_tracer']['slow_sql'] }
+attribute :transaction_tracer_explain_threshold, :default => lazy { node['newrelic']['application_monitoring']['transaction_tracer']['explain_threshold'] }
+attribute :error_collector_enable, :default => lazy { node['newrelic']['application_monitoring']['error_collector']['enable'] }
+attribute :error_collector_ignore_errors, :default => lazy { node['newrelic']['application_monitoring']['error_collector']['ignore_errors'] }
+attribute :error_collector_ignore_classes, :default => lazy { node['newrelic']['application_monitoring']['error_collector']['ignore_classes'] }
+attribute :error_collector_ignore_status_codes, :default => lazy { node['newrelic']['application_monitoring']['error_collector']['ignore_status_codes'] }
+attribute :browser_monitoring_auto_instrument, :default => lazy { node['newrelic']['application_monitoring']['browser_monitoring']['auto_instrument'] }
+attribute :cross_application_tracer_enable, :default => lazy { node['newrelic']['application_monitoring']['browser_monitoring']['auto_instrument'] }
+attribute :thread_profiler_enable, :default => lazy { node['newrelic']['application_monitoring']['thread_profiler']['enable'] }
+attribute :labels, :default => lazy { node['newrelic']['application_monitoring']['labels'] }


### PR DESCRIPTION
Fixes #368.

Should allow chefspec to function normally with regards to resource preloading.