### PR TITLE
Add explicit circuit breaker configuration for java agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,9 +427,6 @@ The `newrelic_agent_java` resource will handle the requirements to install java 
 * `'log_file_count'` - Defaults to nil
 * `'log_limit_in_kbytes'` - Defaults to nil
 * `'log_daily'` - Defaults to false
-* `'circuitbreaker_enabled'` - Defaults to true
-* `'circuitbreaker_memory_threshold'` - Defaults to 20
-* `'circuitbreaker_gc_cpu_threshold'` - Defaults to 10
 * `'daemon_ssl'` - Defaults to true
 * `'daemon_proxy'` - Defaults to nil
 * `'daemon_proxy_host'` - Defaults to nil

--- a/resources/agent_java.rb
+++ b/resources/agent_java.rb
@@ -32,9 +32,6 @@ attribute :audit_mode, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :log_file_count, :kind_of => Integer, :default => nil
 attribute :log_limit_in_kbytes, :kind_of => Integer, :default => nil
 attribute :log_daily, :kind_of => [TrueClass, FalseClass], :default => false
-attribute :circuitbreaker_enabled, :kind_of => [TrueClass, FalseClass], :default => true
-attribute :circuitbreaker_memory_threshold, :kind_of => Integer, :default => 20
-attribute :circuitbreaker_gc_cpu_threshold, :kind_of => Integer, :default => 10
 attribute :daemon_ssl, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :daemon_proxy, :kind_of => String, :default => nil
 attribute :daemon_proxy_host, :kind_of => String, :default => nil

--- a/templates/default/agent/newrelic.yml.erb
+++ b/templates/default/agent/newrelic.yml.erb
@@ -29,19 +29,6 @@ common: &default_settings
   agent_enabled: <%= @resource.enabled %>
   <% end -%>
 
-  # Circuit breaker configuration
-  # Enabled by default with values:
-  # Memory threshold: 20%
-  # Garbage collection CPU threshold: 10%
-  circuitbreaker:
-  <% if @resource.circuitbreaker_enabled.nil? -%>
-    enabled: false
-  <% else -%>
-    enabled: true
-    memory_threshold: <%= @resource.circuitbreaker_memory_threshold %>
-    gc_cpu_threshold: <%= @resource.circuitbreaker_gc_cpu_threshold %>
-  <% end -%>
-
   # Set to true to enable support for auto app naming.
   # The name of each web app is detected automatically
   # and the agent reports data separately for each one.


### PR DESCRIPTION
Added explicit circuit breaker configuration for java agent, with default settings.
It allows to adjust properties for circuit breaker or disable it completely using attributes.