### PR TITLE
Ubuntu 18.04 support

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -83,7 +83,8 @@ module NewRelic
         10 => 'buster',
         12 => 'precise',
         14 => 'trusty',
-        16 => 'xenial'
+        16 => 'xenial',
+        18 => 'bionic'
       }
 
       deb_version_to_codename[version]


### PR DESCRIPTION
The helper was not resolving on Ubuntu 18.04, leaving us with a broken `/etc/apt/sources.list.d/newrelic-infra.list` file. 
This line allows the cookbook to create the expected entry.

Daniel