### PR TITLE
Add Distributed Tracing support for the .NET Agent

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,6 +3,8 @@ driver_plugin: vagrant
 
 provisioner:
   name: chef_zero
+  client_rb:
+    chef_license: accept
   attributes:
     newrelic:
       license: '0000ffff0000ffff0000ffff0000ffff0000ffff'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,13 @@ services: docker
 # https://docs.travis-ci.com/user/customizing-the-build/#Skipping-the-Installation-Step
 install: true
 
+env:
+  - CHEF_LICENSE="accept"
+
 before_script:
   - eval "$(/opt/chefdk/bin/chef shell-init bash)" # make ChefDK's Ruby the default
   - chef --version
-  - chef exec berks install --chef-license accept
+  - chef exec berks install
 
 script:
   - chef exec rake travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install: true
 before_script:
   - eval "$(/opt/chefdk/bin/chef shell-init bash)" # make ChefDK's Ruby the default
   - chef --version
-  - chef exec berks install
+  - chef exec berks install --accept-license
 
 script:
   - chef exec rake travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install: true
 before_script:
   - eval "$(/opt/chefdk/bin/chef shell-init bash)" # make ChefDK's Ruby the default
   - chef --version
-  - chef exec berks install --accept-license
+  - chef exec berks install --chef-license accept
 
 script:
   - chef exec rake travis

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ module GeneralCommands
     expected_exitstatuses << 0 if expected_exitstatuses.empty?
     error_message = "ERROR: '#{cmd}' failed with exit status #{$CHILD_STATUS.exitstatus}"
     raise StandardError, error_message unless [expected_exitstatuses].flatten.include?($CHILD_STATUS.exitstatus)
-    
+
     output
   end
 
@@ -34,7 +34,7 @@ module ReleaseCommands
     modified_files = modified_files.split(/\n+/)
 
     return if allowed_modified_files.uniq.sort == modified_files.uniq.sort
-    
+
     raise '[RELEASE] Working directory is in an unexpected state'
   end
 
@@ -133,7 +133,7 @@ end
 module BerkshelfCommands
   def self.update
     return if GeneralCommands.run('chef exec berks update', 0, 1)
-    
+
     raise '[BERKSHELF] Failed to update'
   end
 
@@ -141,7 +141,7 @@ module BerkshelfCommands
     raise '[BERKSHELF] You must specify an archive filename.' if archive_filename.blank?
 
     return if GeneralCommands.run("chef exec berks package #{archive_filename}", 0, 1)
-    
+
     raise "[BERKSHELF] Failed to create #{archive_filename}-archive"
   end
 
@@ -149,7 +149,7 @@ module BerkshelfCommands
     raise '[BERKSHELF] You must specify an environment.' if environment.blank?
 
     return unless GeneralCommands.run("chef exec berks apply #{environment}", 0, 1).empty?
-    
+
     raise "[BERKSHELF] Failed to apply the cookbook version locks to the '#{environment}'-Chef environment"
   end
 end
@@ -160,7 +160,7 @@ module BerkflowCommands
     raise '[BERKFLOW] You must specify an archive filename.' if archive_filename.blank?
 
     return if /Done./ =~ GeneralCommands.run("chef exec blo in #{archive_filename}", 0, 1)
-    
+
     raise "[BERKFLOW] Failed to install packaged cookbooks #{archive_filename} into Chef Server"
   end
 end
@@ -178,7 +178,7 @@ module GitCommands
     raise '[GIT] You must specify a tag.' if tag.blank?
 
     return if GeneralCommands.run("git tag -a #{tag} -m '#{tag}'", 0, 1)
-    
+
     raise '[GIT] Failed to tag'
   end
 
@@ -188,7 +188,7 @@ module GitCommands
     raise '[GIT] You must specify a tag.' if tag.blank?
 
     return if GeneralCommands.run("git push #{remote} #{branch} --tags", 0, 1)
-    
+
     raise '[GIT] Failed to push to remote'
   end
 end
@@ -200,7 +200,7 @@ module KnifeCommands
     raise '[KNIFE] Missing cookbook category.' if cookbook_category.blank?
 
     return if /Upload complete/ =~ GeneralCommands.run("chef exec knife supermarket share '#{cookbook_name}' '#{cookbook_category}' --cookbook-path ../", 0, 1)
-    
+
     raise "[KNIFE] Failed to publish the #{cookbook_name}-cookbook on the Chef Supermarket"
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,7 @@ module GeneralCommands
     expected_exitstatuses << 0 if expected_exitstatuses.empty?
     error_message = "ERROR: '#{cmd}' failed with exit status #{$CHILD_STATUS.exitstatus}"
     raise StandardError, error_message unless [expected_exitstatuses].flatten.include?($CHILD_STATUS.exitstatus)
+    
     output
   end
 
@@ -33,6 +34,7 @@ module ReleaseCommands
     modified_files = modified_files.split(/\n+/)
 
     return if allowed_modified_files.uniq.sort == modified_files.uniq.sort
+    
     raise '[RELEASE] Working directory is in an unexpected state'
   end
 
@@ -131,6 +133,7 @@ end
 module BerkshelfCommands
   def self.update
     return if GeneralCommands.run('chef exec berks update', 0, 1)
+    
     raise '[BERKSHELF] Failed to update'
   end
 
@@ -138,6 +141,7 @@ module BerkshelfCommands
     raise '[BERKSHELF] You must specify an archive filename.' if archive_filename.blank?
 
     return if GeneralCommands.run("chef exec berks package #{archive_filename}", 0, 1)
+    
     raise "[BERKSHELF] Failed to create #{archive_filename}-archive"
   end
 
@@ -145,6 +149,7 @@ module BerkshelfCommands
     raise '[BERKSHELF] You must specify an environment.' if environment.blank?
 
     return unless GeneralCommands.run("chef exec berks apply #{environment}", 0, 1).empty?
+    
     raise "[BERKSHELF] Failed to apply the cookbook version locks to the '#{environment}'-Chef environment"
   end
 end
@@ -155,6 +160,7 @@ module BerkflowCommands
     raise '[BERKFLOW] You must specify an archive filename.' if archive_filename.blank?
 
     return if /Done./ =~ GeneralCommands.run("chef exec blo in #{archive_filename}", 0, 1)
+    
     raise "[BERKFLOW] Failed to install packaged cookbooks #{archive_filename} into Chef Server"
   end
 end
@@ -172,6 +178,7 @@ module GitCommands
     raise '[GIT] You must specify a tag.' if tag.blank?
 
     return if GeneralCommands.run("git tag -a #{tag} -m '#{tag}'", 0, 1)
+    
     raise '[GIT] Failed to tag'
   end
 
@@ -181,6 +188,7 @@ module GitCommands
     raise '[GIT] You must specify a tag.' if tag.blank?
 
     return if GeneralCommands.run("git push #{remote} #{branch} --tags", 0, 1)
+    
     raise '[GIT] Failed to push to remote'
   end
 end
@@ -192,6 +200,7 @@ module KnifeCommands
     raise '[KNIFE] Missing cookbook category.' if cookbook_category.blank?
 
     return if /Upload complete/ =~ GeneralCommands.run("chef exec knife supermarket share '#{cookbook_name}' '#{cookbook_category}' --cookbook-path ../", 0, 1)
+    
     raise "[KNIFE] Failed to publish the #{cookbook_name}-cookbook on the Chef Supermarket"
   end
 end

--- a/resources/agent_dotnet.rb
+++ b/resources/agent_dotnet.rb
@@ -89,6 +89,9 @@ attribute :tx_tracer_record_sql, :kind_of => String, :default => 'obfuscated'
 attribute :tx_tracer_explain_enabled, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :tx_tracer_explain_threshold, :kind_of => Integer, :default => 500
 attribute :tx_tracer_max_segments, :kind_of => Integer, :default => 3_000
+
+attribute :distributed_tracing_enabled, :kind_of => [TrueClass, FalseClass], :default => true
+
 attribute :tx_tracer_max_stack_trace, :kind_of => Integer, :default => 30
 attribute :tx_tracer_max_explain_plans, :kind_of => Integer, :default => 20
 attribute :tx_tracer_attributes_collection_enabled, :kind_of => [TrueClass, FalseClass], :default => true

--- a/resources/agent_dotnet.rb
+++ b/resources/agent_dotnet.rb
@@ -90,7 +90,7 @@ attribute :tx_tracer_explain_enabled, :kind_of => [TrueClass, FalseClass], :defa
 attribute :tx_tracer_explain_threshold, :kind_of => Integer, :default => 500
 attribute :tx_tracer_max_segments, :kind_of => Integer, :default => 3_000
 
-attribute :distributed_tracing_enabled, :kind_of => [TrueClass, FalseClass], :default => true
+attribute :distributed_tracing_enabled, :kind_of => [TrueClass, FalseClass], :default => false
 
 attribute :tx_tracer_max_stack_trace, :kind_of => Integer, :default => 30
 attribute :tx_tracer_max_explain_plans, :kind_of => Integer, :default => 20

--- a/templates/default/agent/dotnet/newrelic.config.erb
+++ b/templates/default/agent/dotnet/newrelic.config.erb
@@ -41,6 +41,8 @@
     <name><%= app_name %></name>
     <% end %>
   </application>
+  
+  <distributedTracing enabled="<%= @resource.distributed_tracing_enabled %>" />
 
   <instrumentation log="<%= @resource.instrumentation_log_enable %>">
     <% unless @resource.instrumentation_applications.empty? -%>


### PR DESCRIPTION
Reference issue #379 

The existing cookbook does not support Distributed Tracing (last update to it was before Distributed Tracing support was rolled out by New Relic). This will add that support to the dotnet agent but updating the `newrelic.config.erb` template and the `agent_dotnet.rb` custom attribute. Default setting is `false` to prevent impact to anyone currently using the cookbook as well as to match New Relic's default setting for new .NET APM Agent installs.