### PR TITLE
Add circuit breaker configuration on java_agent recipe

### DIFF
--- a/recipes/java_agent.rb
+++ b/recipes/java_agent.rb
@@ -53,7 +53,7 @@ newrelic_agent_java 'Install' do
   trim_stats node['newrelic']['java_agent']['trim_stats'] unless node['newrelic']['java_agent']['trim_stats'].nil?
   agent_action node['newrelic']['java_agent']['agent_action'] unless node['newrelic']['java_agent']['agent_action'].nil?
   execute_agent_action node['newrelic']['java_agent']['execute_agent_action'] unless node['newrelic']['java_agent']['execute_agent_action'].nil?
-  circuitbreaker_enable node['newrelic']['java_agent']['circuitbreaker_enable'] unless node['newrelic']['java_agent']['circuitbreaker_enable'].nil?
+  circuitbreaker_enabled node['newrelic']['java_agent']['circuitbreaker_enable'] unless node['newrelic']['java_agent']['circuitbreaker_enable'].nil?
   circuitbreaker_memory_threshold node['newrelic']['java_agent']['circuitbreaker_memory_threshold'] unless node['newrelic']['java_agent']['circuitbreaker_memory_threshold'].nil?
   circuitbreaker_gc_cpu_threshold node['newrelic']['java_agent']['circuitbreaker_gc_cpu_threshold'] unless node['newrelic']['java_agent']['circuitbreaker_gc_cpu_threshold'].nil?
 end

--- a/recipes/java_agent.rb
+++ b/recipes/java_agent.rb
@@ -53,7 +53,7 @@ newrelic_agent_java 'Install' do
   trim_stats node['newrelic']['java_agent']['trim_stats'] unless node['newrelic']['java_agent']['trim_stats'].nil?
   agent_action node['newrelic']['java_agent']['agent_action'] unless node['newrelic']['java_agent']['agent_action'].nil?
   execute_agent_action node['newrelic']['java_agent']['execute_agent_action'] unless node['newrelic']['java_agent']['execute_agent_action'].nil?
-  circuitbreaker_enabled node['newrelic']['java_agent']['circuitbreaker_enable'] unless node['newrelic']['java_agent']['circuitbreaker_enable'].nil?
+  circuitbreaker_enabled node['newrelic']['java_agent']['circuitbreaker_enabled'] unless node['newrelic']['java_agent']['circuitbreaker_enabled'].nil?
   circuitbreaker_memory_threshold node['newrelic']['java_agent']['circuitbreaker_memory_threshold'] unless node['newrelic']['java_agent']['circuitbreaker_memory_threshold'].nil?
   circuitbreaker_gc_cpu_threshold node['newrelic']['java_agent']['circuitbreaker_gc_cpu_threshold'] unless node['newrelic']['java_agent']['circuitbreaker_gc_cpu_threshold'].nil?
 end

--- a/recipes/java_agent.rb
+++ b/recipes/java_agent.rb
@@ -53,4 +53,7 @@ newrelic_agent_java 'Install' do
   trim_stats node['newrelic']['java_agent']['trim_stats'] unless node['newrelic']['java_agent']['trim_stats'].nil?
   agent_action node['newrelic']['java_agent']['agent_action'] unless node['newrelic']['java_agent']['agent_action'].nil?
   execute_agent_action node['newrelic']['java_agent']['execute_agent_action'] unless node['newrelic']['java_agent']['execute_agent_action'].nil?
+  circuitbreaker_enable node['newrelic']['java_agent']['circuitbreaker_enable'] unless node['newrelic']['java_agent']['circuitbreaker_enable'].nil?
+  circuitbreaker_memory_threshold node['newrelic']['java_agent']['circuitbreaker_memory_threshold'] unless node['newrelic']['java_agent']['circuitbreaker_memory_threshold'].nil?
+  circuitbreaker_gc_cpu_threshold node['newrelic']['java_agent']['circuitbreaker_gc_cpu_threshold'] unless node['newrelic']['java_agent']['circuitbreaker_gc_cpu_threshold'].nil?
 end

--- a/templates/default/agent/newrelic.yml.erb
+++ b/templates/default/agent/newrelic.yml.erb
@@ -319,7 +319,7 @@ common: &default_settings
   <% if @resource.circuitbreaker_enabled.nil? -%>
     enabled: false
   <% else -%>
-    enabled: true
+    enabled: <%= @resource.circuitbreaker_enabled %>
     memory_threshold: <%= @resource.circuitbreaker_memory_threshold %>
     gc_cpu_threshold: <%= @resource.circuitbreaker_gc_cpu_threshold %>
   <% end -%>

--- a/templates/default/agent/newrelic.yml.erb
+++ b/templates/default/agent/newrelic.yml.erb
@@ -316,13 +316,13 @@ common: &default_settings
   # Memory threshold: 20%
   # Garbage collection CPU threshold: 10%
   circuitbreaker:
-  <% if @resource.circuitbreaker_enabled.nil? -%>
+    <% if @resource.circuitbreaker_enabled.nil? -%>
     enabled: false
-  <% else -%>
+    <% else -%>
     enabled: <%= @resource.circuitbreaker_enabled %>
     memory_threshold: <%= @resource.circuitbreaker_memory_threshold %>
     gc_cpu_threshold: <%= @resource.circuitbreaker_gc_cpu_threshold %>
-  <% end -%>
+    <% end -%>
 
   # Distributed tracing lets you see the path that a request takes through your distributed system.
   # Enabling distributed tracing changes the behavior of some New Relic features, so carefully consult the transition


### PR DESCRIPTION
Add missing circuit breaker configuration on java_agent recipe

This past merge https://github.com/djoos-cookbooks/newrelic/pull/375/commits/2f26fdb3433cfc4deaddd2dc6e73551c7c85133e

missed to add the configurations into the java_agent.rb recipe hence the new circuit breaker features are not being applied when implementing the updated cookbook v2.40.3