### PR TITLE
add distributed tracing to php agent resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,8 @@ The `newrelic_agent_php` resource will handle the requirements to install php ap
 * `'webtransaction_name_functions'` - Defaults to nil
 * `'webtransaction_name_files'` - Defaults to nil
 * `'cross_application_tracer_enable'` - Defaults to true
+* `'distributed_tracing_enabled'` - Defaults to false
+* `'distributed_tracing_exclude_newrelic_header'` - Default to false
 
 #### Example
 

--- a/resources/agent_php.rb
+++ b/resources/agent_php.rb
@@ -42,6 +42,8 @@ attribute :daemon_pidfile, :kind_of => String, :default => nil
 attribute :daemon_location, :kind_of => String, :default => nil
 attribute :daemon_collector_host, :kind_of => String, :default => nil
 attribute :daemon_dont_launch, :kind_of => String, :default => nil
+attribute :distributed_tracing_enabled, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :distributed_tracing_exclude_newrelic_header, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :capture_params, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :ignored_params, :kind_of => String, :default => nil
 attribute :error_collector_enable, :kind_of => [TrueClass, FalseClass], :default => true

--- a/templates/default/agent/php/newrelic.ini.erb
+++ b/templates/default/agent/php/newrelic.ini.erb
@@ -676,3 +676,33 @@ newrelic.error_collector.ignore_errors = <%= @resource.error_collector_ignore_er
 <% @resource.additional_config.each do |config, value|%>
 <%= config %> = "<%= value %>"
 <% end %>
+
+;
+; Setting: newrelic.distributed_tracing_enabled
+; Type   : Boolean
+; Scope  : per-directory
+; Default: false
+; Info   : Enable or disable distributed tracing. When the agent's
+;          transaction tracer and distributed tracing features are
+;          enabled, the agent will insert headers into outbound
+;          requests, and scan incoming requests for distributed
+;          tracing headers.
+newrelic.distributed_tracing_enabled = <%= @resource.distributed_tracing_enabled %>
+
+;
+; Setting: newrelic.distributed_tracing_exclude_newrelic_header
+; Type   : Boolean
+; Scope  : per-directory
+; Default: false
+; Info   : Set this to true to exclude the New Relic
+;          distributed tracing header that is attached to outbound
+;          requests, and to instead only rely on W3C Trace Context
+;          Headers for distributed tracing. If this is false then
+;          both types of headers are attached to outbound requests.
+;
+;          The New Relic distributed tracing header allows
+;          interoperability with older agents that do not support
+;          W3C Trace Context headers. Agent versions that support
+;          W3C Trace Context headers will prioritize them over New
+;          Relic headers for distributed tracing.
+newrelic.distributed_tracing_exclude_newrelic_header = <%= @resource.distributed_tracing_exclude_newrelic_header %>


### PR DESCRIPTION
Add distributed tracing options to php agent resource.

* `'distributed_tracing_enabled'` - Defaults to false
* `'distributed_tracing_exclude_newrelic_header'` - Default to false