### PR TITLE
Adds PHP Agent version attribute to allow pinning the version

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ The `newrelic_agent_php` resource will handle the requirements to install php ap
 
 #### Attribute parameters
 
+* `'version'` - PHP Agent version, defaults to latest
 * `'license'` - New Relic license key
 * `'install_silently'` - Determine whether to run the install in silent mode, defaults to false
 * `'app_name'` - The application name, defaults to `PHP Application`.

--- a/attributes/php_agent.rb
+++ b/attributes/php_agent.rb
@@ -5,6 +5,7 @@
 # Copyright (c) 2016, David Joos
 #
 
+default['newrelic']['php_agent']['version'] = nil
 default['newrelic']['php_agent']['agent_action'] = nil
 default['newrelic']['php_agent']['install_silently'] = nil
 default['newrelic']['php_agent']['startup_mode'] = nil

--- a/providers/agent_php.rb
+++ b/providers/agent_php.rb
@@ -58,6 +58,7 @@ def newrelic_php_agent
   package 'newrelic-php5' do
     action new_resource.action
     notifies :run, 'execute[newrelic-install]', :immediately
+    version new_resource.version
   end
 end
 

--- a/recipes/php_agent.rb
+++ b/recipes/php_agent.rb
@@ -7,6 +7,7 @@
 
 newrelic_agent_php 'Install' do
   license lazy { NewRelic.application_monitoring_license(node) }
+  version node['newrelic']['php_agent']['version'] unless node['newrelic']['php_agent']['version'].nil?
   config_file node['newrelic']['php_agent']['config_file'] unless node['newrelic']['php_agent']['config_file'].nil?
   startup_mode node['newrelic']['php_agent']['startup_mode'] unless node['newrelic']['php_agent']['startup_mode'].nil?
   app_name node['newrelic']['application_monitoring']['app_name'] unless node['newrelic']['application_monitoring']['app_name'].nil?

--- a/resources/agent_php.rb
+++ b/resources/agent_php.rb
@@ -9,6 +9,7 @@ actions :install, :remove
 default_action :install
 
 attribute :license, :kind_of => String, :default => lazy { NewRelic.application_monitoring_license(node) }
+attribute :version, :kind_of => String, :default => nil
 attribute :config_file, :kind_of => String, :default => nil
 attribute :startup_mode, :kind_of => String, :default => 'agent'
 attribute :app_name, :kind_of => String, :default => nil


### PR DESCRIPTION
This change allows you to set the `'version'` attribute of `'php_agent'` to install and pin a specific New Relic agent cookbook.

This can be useful as I have seen one occasion where a New Relic PHP agent release has caused performance issues and needed to be rolled back.

I wanted to add some kind of test for this but I couldn't figure out how to do that within the current setup. I'm more than willing to put more time into that if needed.