### PR TITLE
Fixed PHP Agent Distributed Tracing

### DIFF
--- a/recipes/php_agent.rb
+++ b/recipes/php_agent.rb
@@ -37,6 +37,7 @@ newrelic_agent_php 'Install' do
   daemon_location node['newrelic']['application_monitoring']['daemon']['location'] unless node['newrelic']['application_monitoring']['daemon']['location'].nil?
   daemon_collector_host node['newrelic']['application_monitoring']['daemon']['collector_host'] unless node['newrelic']['application_monitoring']['daemon']['collector_host'].nil?
   daemon_dont_launch node['newrelic']['application_monitoring']['daemon']['dont_launch'] unless node['newrelic']['application_monitoring']['daemon']['dont_launch'].nil?
+  distributed_tracing_enabled NewRelic.to_boolean(node['newrelic']['application_monitoring']['distributed_tracing_enabled']) unless node['newrelic']['application_monitoring']['distributed_tracing_enabled'].nil?
   capture_params NewRelic.to_boolean(node['newrelic']['application_monitoring']['capture_params']) unless node['newrelic']['application_monitoring']['capture_params'].nil?
   ignored_params node['newrelic']['application_monitoring']['ignored_params'] unless node['newrelic']['application_monitoring']['ignored_params'].nil?
   error_collector_enable NewRelic.to_boolean(node['newrelic']['application_monitoring']['error_collector']['enable']) unless node['newrelic']['application_monitoring']['error_collector']['enable'].nil?

--- a/recipes/php_agent.rb
+++ b/recipes/php_agent.rb
@@ -38,6 +38,7 @@ newrelic_agent_php 'Install' do
   daemon_collector_host node['newrelic']['application_monitoring']['daemon']['collector_host'] unless node['newrelic']['application_monitoring']['daemon']['collector_host'].nil?
   daemon_dont_launch node['newrelic']['application_monitoring']['daemon']['dont_launch'] unless node['newrelic']['application_monitoring']['daemon']['dont_launch'].nil?
   distributed_tracing_enabled NewRelic.to_boolean(node['newrelic']['application_monitoring']['distributed_tracing_enabled']) unless node['newrelic']['application_monitoring']['distributed_tracing_enabled'].nil?
+  distributed_tracing_exclude_newrelic_header NewRelic.to_boolean(node['newrelic']['application_monitoring']['distributed_tracing_exclude_newrelic_header']) unless node['newrelic']['application_monitoring']['distributed_tracing_exclude_newrelic_header'].nil?
   capture_params NewRelic.to_boolean(node['newrelic']['application_monitoring']['capture_params']) unless node['newrelic']['application_monitoring']['capture_params'].nil?
   ignored_params node['newrelic']['application_monitoring']['ignored_params'] unless node['newrelic']['application_monitoring']['ignored_params'].nil?
   error_collector_enable NewRelic.to_boolean(node['newrelic']['application_monitoring']['error_collector']['enable']) unless node['newrelic']['application_monitoring']['error_collector']['enable'].nil?

--- a/templates/default/agent/php/newrelic.ini.erb
+++ b/templates/default/agent/php/newrelic.ini.erb
@@ -687,7 +687,11 @@ newrelic.error_collector.ignore_errors = <%= @resource.error_collector_ignore_er
 ;          enabled, the agent will insert headers into outbound
 ;          requests, and scan incoming requests for distributed
 ;          tracing headers.
+<% if @resource.distributed_tracing_enabled.nil? %>
+;newrelic.distributed_tracing_enabled = false
+<% else %>
 newrelic.distributed_tracing_enabled = <%= @resource.distributed_tracing_enabled %>
+<% end %>
 
 ;
 ; Setting: newrelic.distributed_tracing_exclude_newrelic_header
@@ -705,4 +709,8 @@ newrelic.distributed_tracing_enabled = <%= @resource.distributed_tracing_enabled
 ;          W3C Trace Context headers. Agent versions that support
 ;          W3C Trace Context headers will prioritize them over New
 ;          Relic headers for distributed tracing.
+<% if @resource.distributed_tracing_exclude_newrelic_header? %>
+;newrelic.distributed_tracing_exclude_newrelic_header = false
+<% else %>
 newrelic.distributed_tracing_exclude_newrelic_header = <%= @resource.distributed_tracing_exclude_newrelic_header %>
+<% end %>

--- a/templates/default/agent/php/newrelic.ini.erb
+++ b/templates/default/agent/php/newrelic.ini.erb
@@ -709,7 +709,7 @@ newrelic.distributed_tracing_enabled = <%= @resource.distributed_tracing_enabled
 ;          W3C Trace Context headers. Agent versions that support
 ;          W3C Trace Context headers will prioritize them over New
 ;          Relic headers for distributed tracing.
-<% if @resource.distributed_tracing_exclude_newrelic_header? %>
+<% if @resource.distributed_tracing_exclude_newrelic_header.nil? %>
 ;newrelic.distributed_tracing_exclude_newrelic_header = false
 <% else %>
 newrelic.distributed_tracing_exclude_newrelic_header = <%= @resource.distributed_tracing_exclude_newrelic_header %>


### PR DESCRIPTION
#386 implemented the Distributed Tracing configuration to the PHP Agent. However, it missed a key bit of code in `recipes/php_agent.rb` that applies the attribute.

I've also changed the styling of the `newrelic.ini.erb` to match the rest of the attributes that produce a commented out value by default.

I tested this manually on my own resources. Distributed tracing successfully enables using this branch.

Resolves #390 