### PR TITLE
Ubuntu 20.04 support

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -84,7 +84,8 @@ module NewRelic
         12 => 'precise',
         14 => 'trusty',
         16 => 'xenial',
-        18 => 'bionic'
+        18 => 'bionic',
+        20 => 'focal'
       }
 
       deb_version_to_codename[version]


### PR DESCRIPTION
The helper function `deb_version_to_codename` didn't have 20 to 'focal' conversion causing the chef run to break apt because it couldn't resolve a distribution