### PR TITLE
Add Support for Ubuntu 22.04 and 24.04 to deb_version_to_codename

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -86,6 +86,8 @@ module NewRelic
         16 => 'xenial',
         18 => 'bionic',
         20 => 'focal',
+        22 => 'jammy',
+        24 => 'noble'
       }
 
       deb_version_to_codename[version]


### PR DESCRIPTION
Updated function to include the source names for both versions to stop cookbook failures at this point in the install process