### PR TITLE
Allow support for the ARM repository in Debian

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -60,7 +60,6 @@ module NewRelic
         distribution deb_version_to_codename(node['platform_version'].to_i)
         components node['newrelic']['repository']['infrastructure']['components']
         key node['newrelic']['repository']['infrastructure']['key']
-        arch 'amd64'
       end
     end
 

--- a/providers/agent_php.rb
+++ b/providers/agent_php.rb
@@ -17,7 +17,7 @@ action :install do
 
   current_working_directory = nil
 
-  if arm?
+  if arm? && (node['platform_family'] != 'debian' || (node['platform'] == 'ubuntu' && node['platform_version'].to_f < 22.04))
     dir = Chef::Config[:file_cache_path]
     filename = "newrelic-php5-#{new_resource.version}-linux"
 

--- a/providers/agent_php.rb
+++ b/providers/agent_php.rb
@@ -17,7 +17,7 @@ action :install do
 
   current_working_directory = nil
 
-  if arm? && (node['platform_family'] != 'debian' || (node['platform'] == 'ubuntu' && node['platform_version'].to_f < 22.04))
+  if arm?
     dir = Chef::Config[:file_cache_path]
     filename = "newrelic-php5-#{new_resource.version}-linux"
 


### PR DESCRIPTION
Currently the `install_newrelic_repo_infrastructure_debian` function hardcodes the repo to be `amd64` causing failures for the NR Infra package install on ARM devices due to the package not being found. (And I got PR ID 404, nice coincidence) 

Removing it allows chef to pick the correct arch and with NR supporting ARM this should now be a feasible option going forward.